### PR TITLE
Exclude headings with class `.toc-exclude`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - v*.*.* # only trigger on version tags
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,4 @@ publish = "build"
 
 [build.environment]
 NODE_VERSION = "17.6.0"
-YARN_VERSION = "1.22.11"
+YARN_VERSION = "1.22.17"

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ In a SvelteKit project:
 
 Full list of props and bindable variables for this component (all of them optional):
 
-- `headingSelector` (`string`, default: `'main :where(h1, h2, h3, h4)'`): CSS selector string that should return all headings to list in the ToC. You can try out selectors in the dev console of your live page to make sure they return what you want by passing it into `[...document.querySelectorAll(headingSelector)]`.
+- `headingSelector` (`string`, default: `'main :where(h1, h2, h3, h4):not(.toc-exclude)'`): CSS selector string that should return all headings to list in the ToC. You can try out selectors in the dev console of your live page to make sure they return what you want by passing it into `[...document.querySelectorAll(headingSelector)]`.
 - `getHeadingTitles` (`function`, default: `(node) => node.innerText`): Function that receives each DOM node matching `headingSelector` and returns the string to display in the TOC.
 - `getHeadingIds` (`function`, default: `(node) => node.id`): Function that receives each DOM node matching `headingSelector` and returns the string to set the URL hash to when clicking the associated ToC entry. Set to `null` to prevent updating the URL hash on ToC clicks if e.g. your headings don't have IDs.
 - `getHeadingLevels` (`function`, default: `(node) => Number(node.nodeName[1])`): Function that receives each DOM node matching `headingSelector` and returns an integer from 1 to 6 for the ToC depth (determines indentation and font-size).

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,7 @@ The HTML structure of this component is
   - `color: var(--toc-active-color, whitesmoke)`: Text color of the currently active heading (the one nearest but above top side of current viewport scroll position).
   - `background: var(--toc-active-bg, cornflowerblue)`
   - `font-weight: var(--toc-active-font-weight)`
+  - `padding: var(--toc-active-padding)`
 - `aside.toc > button`
   - `color: var(--toc-mobile-btn-color, black)`: Menu icon color of button used as ToC opener on mobile.
   - `background: var(--toc-mobile-btn-bg, rgba(255, 255, 255, 0.2))`: Background of padding area around the menu icon button.

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 
 </h4>
 
-Sticky responsive table of contents component for SvelteKit.
+Sticky responsive table of contents component for SvelteKit. <strong class="hide-in-docs"><a href="https://svelte-toc.netlify.app">Live demo</a></strong>
 
 ## Installation
 
@@ -126,7 +126,7 @@ The HTML structure of this component is
 - `aside.toc.desktop`
   - `margin: var(--toc-desktop-aside-margin)`: Margin of the outer-most `aside.toc` element on desktops.
 - `aside.toc.desktop > nav`
-  - `margin: var(--toc-desktop-nav-margin, 0 2ex 0 0)`
+  - `margin: var(--toc-desktop-nav-margin)`
   - `top: var(--toc-desktop-sticky-top, 2em)`: How far below the screen's top edge the ToC starts being sticky.
   - `background-color: var(--toc-desktop-bg)`
 

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -4,7 +4,7 @@
   import { blur } from 'svelte/transition'
   import MenuIcon from './MenuIcon.svelte'
 
-  export let headingSelector = `main :where(h1, h2, h3, h4)`
+  export let headingSelector = `main :where(h1, h2, h3, h4):not(.toc-exclude)`
   export let getHeadingTitles = (node: HTMLHeadingElement): string => node.innerText
   export let getHeadingIds = (node: HTMLHeadingElement): string => node.id
   export let getHeadingLevels = (node: HTMLHeadingElement): number =>
@@ -103,8 +103,8 @@
         {#each headings as heading, idx}
           <li
             tabindex={idx + 1}
-            style="margin-left: {levels[idx] - minLevel}em; font-size: {2 -
-              0.2 * (levels[idx] - minLevel)}ex"
+            style:margin-left="{levels[idx] - minLevel}em"
+            style:font-size="{2 - 0.2 * (levels[idx] - minLevel)}ex"
             class:active={activeHeading === heading}
             on:click={clickHandler(heading)}
           >

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -103,7 +103,7 @@
         {#each headings as heading, idx}
           <li
             tabindex={idx + 1}
-            style:margin-left="{levels[idx] - minLevel}em"
+            style:transform="translateX({levels[idx] - minLevel}em)"
             style:font-size="{2 - 0.2 * (levels[idx] - minLevel)}ex"
             class:active={activeHeading === heading}
             on:click={clickHandler(heading)}
@@ -148,6 +148,7 @@
     background: var(--toc-active-bg, cornflowerblue);
     font-weight: var(--toc-active-font-weight);
     padding: var(--toc-active-padding);
+    margin: var(--toc-active-margin);
     border-radius: 2pt;
   }
   :where(aside.toc > button) {

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -147,8 +147,8 @@
     color: var(--toc-active-color, smokewhite);
     background: var(--toc-active-bg, cornflowerblue);
     font-weight: var(--toc-active-font-weight);
-    padding: 0 4pt;
-    border-radius: 3pt;
+    padding: var(--toc-active-padding);
+    border-radius: 2pt;
   }
   :where(aside.toc > button) {
     position: absolute;
@@ -192,7 +192,7 @@
   :where(aside.toc.desktop > nav) {
     position: sticky;
     padding: 12pt 14pt 0;
-    margin: var(--toc-desktop-nav-margin, 0 2em 0 0);
+    margin: var(--toc-desktop-nav-margin);
     top: var(--toc-desktop-sticky-top, 2em);
     background-color: var(--toc-desktop-bg);
     border-radius: 5pt;

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -5,14 +5,3 @@
 <GitHubCorner href="https://github.com/janosh/svelte-toc" />
 
 <slot />
-
-<style>
-  :global(:root) {
-    --toc-mobile-bg: #484452;
-    --toc-mobile-btn-color: white;
-    --toc-max-width: 15em;
-    --toc-desktop-aside-margin: 20ex 0 0 0;
-    --ghc-color: var(--bg);
-    --ghc-bg: white;
-  }
-</style>

--- a/src/routes/index.svx
+++ b/src/routes/index.svx
@@ -3,8 +3,6 @@
   import Toc from '../lib/Toc.svelte'
 </script>
 
-<Toc headingSelector="main :where(h2, h3)" />
-
 <main>
 
 <Readme />
@@ -15,6 +13,8 @@
 - [Page without ToC](/no-toc-page)
 
 </main>
+
+<Toc headingSelector="main :where(h2, h3):not(.toc-exclude)" />
 
 <style>
   :global(h1) {
@@ -32,5 +32,8 @@
       gap: 1ex;
       margin-bottom: 3rem;
     }
+  }
+  :global(.hide-in-docs) {
+    display: none;
   }
 </style>

--- a/src/routes/long-page.svx
+++ b/src/routes/long-page.svx
@@ -2,8 +2,6 @@
   import Toc from '../lib/Toc.svelte'
 </script>
 
-<Toc />
-
 <main>
 
 # VS Code November 2021 Release Notes (v1.63)
@@ -539,3 +537,5 @@ Last but certainly not least, a big _**Thank You**_ to the contributors of VS Co
 [Back to landing page](/)
 
 </main>
+
+<Toc />

--- a/static/global.css
+++ b/static/global.css
@@ -1,6 +1,12 @@
 :root {
   --bg: #090019;
-  --toc-desktop-bg: rgba(255, 255, 255, 0.05);
+  --toc-mobile-bg: #484452;
+  --toc-mobile-btn-color: white;
+  --toc-max-width: 15em;
+  --toc-active-padding: 2pt 4pt;
+
+  --ghc-color: var(--bg);
+  --ghc-bg: white;
 }
 body {
   background: var(--bg);
@@ -9,9 +15,6 @@ body {
   margin: auto;
   color: #eee;
   overflow-x: hidden;
-}
-* {
-  scroll-margin-top: 100px;
 }
 /* outer div = hydration target */
 body > div {
@@ -54,8 +57,9 @@ blockquote {
   margin: 1em 0;
 }
 :is(h2, h3, h4, h5, h6) {
-  margin-top: 2em;
+  margin-top: 1.2em;
   transition: 0.3s;
+  scroll-margin-top: 100px;
 }
 .toc-clicked {
   color: cornflowerblue;

--- a/static/global.css
+++ b/static/global.css
@@ -4,6 +4,7 @@
   --toc-mobile-btn-color: white;
   --toc-max-width: 15em;
   --toc-active-padding: 2pt 4pt;
+  --toc-active-margin: 0 0 0 -4pt;
 
   --ghc-color: var(--bg);
   --ghc-bg: white;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -33,6 +33,8 @@ export default {
   kit: {
     adapter: adapter(),
 
+    prerender: { default: true },
+
     package: {
       // exclude auxiliary files from package.json "exports"
       exports: (filepath) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "es2020",
-    "target": "es2020",
+    "module": "esnext",
+    "target": "esnext",
 
     // Svelte Preprocess cannot figure out whether you have a value or a type, so tell TypeScript
     // to enforce using `import type` instead of `import` for Types.


### PR DESCRIPTION
Default `headingSelector` is now `main :where(h1, h2, h3, h4):not(.toc-exclude)`.