### PR TITLE
Export headings and desktop and add hide prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,17 +41,20 @@ In a SvelteKit project:
 Full list of props and bindable variables for this component (all of them optional):
 
 - `headingSelector` (`string`, default: `'main :where(h1, h2, h3, h4):not(.toc-exclude)'`): CSS selector string that should return all headings to list in the ToC. You can try out selectors in the dev console of your live page to make sure they return what you want by passing it into `[...document.querySelectorAll(headingSelector)]`.
+- `headings` (`HTMLHeadingElement[]`, `[]`): Array if DOM heading nodes currently listed and tracked by the ToC.
 - `getHeadingTitles` (`function`, default: `(node) => node.innerText`): Function that receives each DOM node matching `headingSelector` and returns the string to display in the TOC.
 - `getHeadingIds` (`function`, default: `(node) => node.id`): Function that receives each DOM node matching `headingSelector` and returns the string to set the URL hash to when clicking the associated ToC entry. Set to `null` to prevent updating the URL hash on ToC clicks if e.g. your headings don't have IDs.
 - `getHeadingLevels` (`function`, default: `(node) => Number(node.nodeName[1])`): Function that receives each DOM node matching `headingSelector` and returns an integer from 1 to 6 for the ToC depth (determines indentation and font-size).
-- `title` (`str`, default: `'Contents'`): ToC title to display above the list of headings. Set `title=''` to hide.
-- `openButtonLabel` (`str`, default: `'Open table of contents'`): What to use as ARIA label for the button shown on mobile screens to open the ToC. Not used on desktop screens.
-- `breakpoint` (`int`, default: `1000`): At what screen width in pixels to break from mobile to desktop styles.
+- `title` (`string`, default: `'Contents'`): ToC title to display above the list of headings. Set `title=''` to hide.
+- `openButtonLabel` (`string`, default: `'Open table of contents'`): What to use as ARIA label for the button shown on mobile screens to open the ToC. Not used on desktop screens.
+- `breakpoint` (`integer`, default: `1000`): At what screen width in pixels to break from mobile to desktop styles.
+- `desktop` (`boolean`, default: `true`): `true` if current window width > `breakpoint` else `false`.
 - `activeTopOffset` (`integer`, default: `100`): Distance to top edge of screen (in pixels) at which a heading jumps from inactive to active. Increase this value if you have a header that makes headings disappear earlier than the viewport's top edge.
 - `open` (`bool`, default: `false`): Whether the ToC is currently in an open state on mobile screens. This value is ignored on desktops.
 - `activeHeading` (`HTMLHeadingElement | null`, default: `null`): The DOM node of the currently active (highlighted) heading (based on the users scroll position on the page).
 - `keepActiveTocItemInView` (`boolean`, default `false`): Whether to scroll the ToC along with the page.
-- `flashClickedHeadingsFor` (`int`, default: `1500`): How long (in milliseconds) a heading clicked in the ToC should receive a class of `.toc-clicked` in the main document. This can be used to help users immediately spot the heading they clicked on after the ToC scrolled it into view. Flash duration is in milliseconds. Set to 0 to disable this behavior. Style `.toc-clicked` however you like, though less is usually more. For example, the demo site uses
+- `flashClickedHeadingsFor` (`integer`, default: `1500`): How long (in milliseconds) a heading clicked in the ToC should receive a class of `.toc-clicked` in the main document. This can be used to help users immediately spot the heading they clicked on after the ToC scrolled it into view. Flash duration is in milliseconds. Set to 0 to disable this behavior. Style `.toc-clicked` however you like, though less is usually more. For example, the demo site uses
+- `hide` (`boolean`, default: `false`): Whether to render or hide the ToC. The reason you would use this and not wrap the component as a whole with Svelte's `{#if}` block is so that the script part of this component can still operate and keep track of the headings on the page, allowing conditional rendering based on the number or kinds of headings present (see [PR#14](https://github.com/janosh/svelte-toc/pull/14)). To access the headings `<Toc>` is currently tracking, use `<Toc bind:headings={myHeadings} />`.
 
   ```css
   :is(h2, h3, h4) {

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -85,12 +85,7 @@
   on:click={close}
 />
 {#if !hide}
-   <aside
-    class="toc"
-    class:desktop
-    class:mobile={!desktop}
-    bind:this={aside}
-  >
+  <aside class="toc" class:desktop class:mobile={!desktop} bind:this={aside}>
     {#if !open && !desktop}
       <button
         on:click|preventDefault|stopPropagation={() => (open = true)}

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -19,7 +19,7 @@
   export let activeTopOffset = 100
   export let headings: HTMLHeadingElement[] = []
   export let desktop = true
-  export let visible = true
+  export let hide = false
 
   let windowWidth: number
   let windowHeight: number
@@ -84,7 +84,7 @@
   on:scroll={setActiveHeading}
   on:click={close}
 />
-{#if visible}
+{#if !hide}
   <aside class="toc" class:desktop class:mobile={!desktop} bind:this={aside}>
     {#if !open && !desktop}
       <button

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -94,7 +94,7 @@
         <MenuIcon width="1em" />
       </button>
     {/if}
-    {#if open || windowWidth > breakpoint}
+    {#if open || desktop}
       <nav transition:blur|local>
         {#if title}
           <h2>{title}</h2>

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -17,13 +17,17 @@
   export let flashClickedHeadingsFor = 1500
   export let keepActiveTocItemInView = true
   export let activeTopOffset = 100
+  export let headings: HTMLHeadingElement[] = []
+  export let desktop = true
+  export let visible = true
 
   let windowWidth: number
   let windowHeight: number
-  let headings: HTMLHeadingElement[] = []
+
   let aside: HTMLElement
   $: levels = headings.map(getHeadingLevels)
   $: minLevel = Math.min(...levels)
+  $: desktop = (windowWidth > breakpoint)
 
   function close(event: MouseEvent) {
     if (!aside.contains(event.target as Node)) open = false
@@ -80,14 +84,14 @@
   on:scroll={setActiveHeading}
   on:click={close}
 />
-
+{#if visible}
 <aside
   class="toc"
-  class:desktop={windowWidth > breakpoint}
-  class:mobile={windowWidth < breakpoint}
+  class:desktop
+  class:mobile={!desktop}
   bind:this={aside}
 >
-  {#if !open && windowWidth < breakpoint}
+  {#if !open && !desktop}
     <button
       on:click|preventDefault|stopPropagation={() => (open = true)}
       aria-label={openButtonLabel}
@@ -95,7 +99,7 @@
       <MenuIcon width="1em" />
     </button>
   {/if}
-  {#if open || windowWidth > breakpoint}
+  {#if open || desktop}
     <nav transition:blur|local>
       {#if title}
         <h2>{title}</h2>
@@ -118,6 +122,7 @@
     </nav>
   {/if}
 </aside>
+{/if}
 
 <style>
   :where(aside.toc) {

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -27,7 +27,7 @@
   let aside: HTMLElement
   $: levels = headings.map(getHeadingLevels)
   $: minLevel = Math.min(...levels)
-  $: desktop = (windowWidth > breakpoint)
+  $: desktop = windowWidth > breakpoint
 
   function close(event: MouseEvent) {
     if (!aside.contains(event.target as Node)) open = false
@@ -85,43 +85,38 @@
   on:click={close}
 />
 {#if visible}
-<aside
-  class="toc"
-  class:desktop
-  class:mobile={!desktop}
-  bind:this={aside}
->
-  {#if !open && !desktop}
-    <button
-      on:click|preventDefault|stopPropagation={() => (open = true)}
-      aria-label={openButtonLabel}
-    >
-      <MenuIcon width="1em" />
-    </button>
-  {/if}
-  {#if open || desktop}
-    <nav transition:blur|local>
-      {#if title}
-        <h2>{title}</h2>
-      {/if}
-      <ul>
-        {#each headings as heading, idx}
-          <li
-            tabindex={idx + 1}
-            style:transform="translateX({levels[idx] - minLevel}em)"
-            style:font-size="{2 - 0.2 * (levels[idx] - minLevel)}ex"
-            class:active={activeHeading === heading}
-            on:click={clickHandler(heading)}
-          >
-            <slot name="tocItem" {heading} {idx}>
-              {getHeadingTitles(heading)}
-            </slot>
-          </li>
-        {/each}
-      </ul>
-    </nav>
-  {/if}
-</aside>
+  <aside class="toc" class:desktop class:mobile={!desktop} bind:this={aside}>
+    {#if !open && !desktop}
+      <button
+        on:click|preventDefault|stopPropagation={() => (open = true)}
+        aria-label={openButtonLabel}
+      >
+        <MenuIcon width="1em" />
+      </button>
+    {/if}
+    {#if open || desktop}
+      <nav transition:blur|local>
+        {#if title}
+          <h2>{title}</h2>
+        {/if}
+        <ul>
+          {#each headings as heading, idx}
+            <li
+              tabindex={idx + 1}
+              style:transform="translateX({levels[idx] - minLevel}em)"
+              style:font-size="{2 - 0.2 * (levels[idx] - minLevel)}ex"
+              class:active={activeHeading === heading}
+              on:click={clickHandler(heading)}
+            >
+              <slot name="tocItem" {heading} {idx}>
+                {getHeadingTitles(heading)}
+              </slot>
+            </li>
+          {/each}
+        </ul>
+      </nav>
+    {/if}
+  </aside>
 {/if}
 
 <style>

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -85,7 +85,12 @@
   on:click={close}
 />
 {#if !hide}
-  <aside class="toc" class:desktop class:mobile={!desktop} bind:this={aside}>
+   <aside
+    class="toc"
+    class:desktop
+    class:mobile={!desktop}
+    bind:this={aside}
+  >
     {#if !open && !desktop}
       <button
         on:click|preventDefault|stopPropagation={() => (open = true)}
@@ -94,7 +99,7 @@
         <MenuIcon width="1em" />
       </button>
     {/if}
-    {#if open || desktop}
+    {#if open || windowWidth > breakpoint}
       <nav transition:blur|local>
         {#if title}
           <h2>{title}</h2>


### PR DESCRIPTION
- Export the array of headings
- Export if desktop is active or not
- Add option to hide toc

Knowing if Toc is in desktop mode enables me to change the layout according to that and change my layout to use the space without having to make extra calculations

I want to hide Toc when there are less than 2 headlines. So the headlines are exported to be able to count them and a hide prop is added to be able to hide the Toc.