### PR TITLE
Mutation observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-toc",
-  "description": "Sticky responsive table of contents component for SvelteKit projects",
+  "description": "Sticky responsive table of contents component written in Svelte",
   "author": "Janosh Riebesell <janosh.riebesell@gmail.com>",
   "homepage": "https://svelte-toc.netlify.app",
   "repository": "https://github.com/janosh/svelte-toc",

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 
 </h4>
 
-Sticky responsive table of contents component for SvelteKit. <strong class="hide-in-docs"><a href="https://svelte-toc.netlify.app">Live demo</a></strong>
+Sticky responsive table of contents component. <strong class="hide-in-docs"><a href="https://svelte-toc.netlify.app">Live demo</a></strong>
 
 ## Installation
 
@@ -22,8 +22,6 @@ yarn add -D svelte-toc
 ```
 
 ## Usage
-
-In a SvelteKit project:
 
 ```svelte
 <script>

--- a/src/routes/+page.svx
+++ b/src/routes/+page.svx
@@ -14,7 +14,7 @@
 
 </main>
 
-<Toc headingSelector="main :where(h2, h3):not(.toc-exclude)" activeTopOffset={200} />
+<Toc headingSelector="main :where(h2, h3)" activeTopOffset={200} />
 
 <style>
   :global(h1) {

--- a/tests/toc.test.ts
+++ b/tests/toc.test.ts
@@ -38,4 +38,33 @@ test.describe(`Toc`, () => {
     )
     expect(active_toc_li).toBe(`Styling`)
   })
+
+  test(`updates when headings are added/removed from the page after load`, async ({
+    page,
+  }) => {
+    await page.goto(`/`, { waitUntil: `networkidle` })
+
+    const add_heading = () => {
+      const newHeading = document.createElement(`h2`)
+      newHeading.textContent = `New Heading`
+      document.querySelector(`main`)?.appendChild(newHeading)
+    }
+    const remove_heading = () => {
+      const headingToRemove = document.querySelector(`h2`)
+      headingToRemove?.remove()
+    }
+    for (const mutation of [add_heading, remove_heading]) {
+      await page.evaluate(mutation)
+
+      const page_headings = await page
+        .locator(`main :where(h2, h3):not(.toc-exclude)`)
+        .allTextContents()
+
+      const toc_headings = (
+        await page.locator(`aside.toc > nav > ul > li`).allTextContents()
+      ).map((li_text) => li_text.trim())
+
+      expect(toc_headings).toEqual(page_headings)
+    }
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,10 @@
 {
+  "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "strict": true,
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "node",
-
-    // Svelte Preprocess cannot figure out whether you have a value or a type, so tell TypeScript
-    // to enforce using `import type` instead of `import` for Types.
-    "importsNotUsedAsValues": "error",
 
     // To have warnings/errors of the Svelte compiler at the correct position,
     // enable source maps by default.


### PR DESCRIPTION
939d5db drop page.subscribe from sveltekit $app/stores in favor of MutationObserver for keeping ToC in sync with page on navigation (and now also DOM insertions/node removals)
54d46aa remove mentions in readme and package.json that this component works only for sveltekit sites
e46f3c9 test ToC updates when adding/removing DOM nodes after load

Related #18 (maybe closes).