### PR TITLE
Fix ToC preventing page scrolling beyond active heading when zoomed into page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 [![NPM version](https://img.shields.io/npm/v/svelte-toc?color=blue&logo=NPM)](https://npmjs.com/package/svelte-toc)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/0238699e-17a8-4423-85de-a5ca30baff0d/deploy-status)](https://app.netlify.com/sites/svelte-toc/deploys)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/janosh/svelte-toc/main.svg)](https://results.pre-commit.ci/latest/github/janosh/svelte-toc/main)
-[![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-darkblue?logo=pytorchlightning)](https://stackblitz.com/github/janosh/svelte-toc)
+[![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-darkblue?logo=stackblitz)](https://stackblitz.com/github/janosh/svelte-toc)
 
 </h4>
 
@@ -42,6 +42,7 @@ Full list of props and bindable variables for this component (all of them option
 - `headingSelector` (`string`, default: `'main :where(h1, h2, h3, h4):not(.toc-exclude)'`): CSS selector string that should return all headings to list in the ToC. You can try out selectors in the dev console of your live page to make sure they return what you want by passing it into `[...document.querySelectorAll(headingSelector)]`.
 - `pageBody` (`string | HTMLElement`, `'body'`): Which DOM node to use as the page body root. All headings to list should be children of this root node. Use the closest parent node containing all headings for efficiency.
 - `headings` (`HTMLHeadingElement[]`, `[]`): Array of DOM heading nodes currently listed and tracked by the ToC. Is bindable but mostly meant for reading, not writing. Deciding which headings to list should be left to the ToC and controlled via `headingSelector`.
+- `tocItems` (`HTMLLIElement[]`, `[]`): Array of rendered Toc list items DOM nodes. Essentially the result of passing `aside.toc > nav > ul > li` to `document.querySelectorAll()`.
 - `getHeadingTitles` (`function`, default: `(node) => node.innerText`): Function that receives each DOM node matching `headingSelector` and returns the string to display in the TOC.
 - `getHeadingIds` (`function`, default: `(node) => node.id`): Function that receives each DOM node matching `headingSelector` and returns the string to set the URL hash to when clicking the associated ToC entry. Set to `null` to prevent updating the URL hash on ToC clicks if e.g. your headings don't have IDs.
 - `getHeadingLevels` (`function`, default: `(node) => Number(node.nodeName[1])`): Function that receives each DOM node matching `headingSelector` and returns an integer from 1 to 6 for the ToC depth (determines indentation and font-size).
@@ -50,9 +51,10 @@ Full list of props and bindable variables for this component (all of them option
 - `openButtonLabel` (`string`, default: `'Open table of contents'`): What to use as ARIA label for the button shown on mobile screens to open the ToC. Not used on desktop screens.
 - `breakpoint` (`integer`, default: `1000`): At what screen width in pixels to break from mobile to desktop styles.
 - `desktop` (`boolean`, default: `true`): `true` if current window width > `breakpoint` else `false`.
-- `activeTopOffset` (`integer`, default: `100`): Distance to top edge of screen (in pixels) at which a heading jumps from inactive to active. Increase this value if you have a header that makes headings disappear earlier than the viewport's top edge.
+- `activeHeadingScrollOffset` (`integer`, default: `100`): Distance in pixels to top edge of screen at which a heading jumps from inactive to active. Increase this value if you have a header that makes headings disappear earlier than the viewport's top edge.
 - `open` (`bool`, default: `false`): Whether the ToC is currently in an open state on mobile screens. This value is ignored on desktops.
 - `activeHeading` (`HTMLHeadingElement | null`, default: `null`): The DOM node of the currently active (highlighted) heading (based on the users scroll position on the page).
+- `activeTocLi` (`HTMLLIElement | null`, default: `null`): The DOM node of the currently active (highlighted) ToC item (based on the users scroll position on the page).
 - `keepActiveTocItemInView` (`boolean`, default `false`): Whether to scroll the ToC along with the page.
 - `flashClickedHeadingsFor` (`integer`, default: `1500`): How long (in milliseconds) a heading clicked in the ToC should receive a class of `.toc-clicked` in the main document. This can be used to help users immediately spot the heading they clicked on after the ToC scrolled it into view. Flash duration is in milliseconds. Set to 0 to disable this behavior. Style `.toc-clicked` however you like, though less is usually more. For example, the demo site uses
 - `hide` (`boolean`, default: `false`): Whether to render or hide the ToC. The reason you would use this and not wrap the component as a whole with Svelte's `{#if}` block is so that the script part of this component can still operate and keep track of the headings on the page, allowing conditional rendering based on the number or kinds of headings present (see [PR#14](https://github.com/janosh/svelte-toc/pull/14)). To access the headings `<Toc>` is currently tracking, use `<Toc bind:headings={myHeadings} />`.
@@ -111,21 +113,25 @@ The HTML structure of this component is
   - `z-index: var(--toc-z-index, 1)`: Applies on both mobile and desktop.
 - `aside.toc > nav`
   - `min-width: var(--toc-min-width)`
-  - `max-width: var(--toc-max-width)`
+  - `max-width: var(--toc-desktop-max-width)`
   - `width: var(--toc-width)`
   - `max-height: var(--toc-max-height, 90vh)`: Height beyond which ToC will use scrolling instead of growing vertically.
 - `aside.toc > nav > ul > li`
   - `scroll-margin: var(--toc-li-scroll-margin, 20pt 0)`: Scroll margin of ToC list items (determines distance from viewport edge (top or bottom) when keeping active ToC item scrolled in view as page scrolls).
+  - `border-radius: var(--toc-li-border-radius, 2pt)`
+  - `padding: var(--toc-li-padding, 2pt 4pt)`
 - `aside.toc > nav > ul > li:hover`
   - `color: var(--toc-hover-color, cornflowerblue)`: Text color of hovered headings.
 - `aside.toc > nav > ul > li.active`
   - `color: var(--toc-active-color, whitesmoke)`: Text color of the currently active heading (the one nearest but above top side of current viewport scroll position).
   - `background: var(--toc-active-bg, cornflowerblue)`
   - `font-weight: var(--toc-active-font-weight)`
-  - `padding: var(--toc-active-padding)`
 - `aside.toc > button`
   - `color: var(--toc-mobile-btn-color, black)`: Menu icon color of button used as ToC opener on mobile.
   - `background: var(--toc-mobile-btn-bg, rgba(255, 255, 255, 0.2))`: Background of padding area around the menu icon button.
+- `aside.toc.mobile`
+  - `bottom: var(--toc-mobile-bottom, 1em)`
+  - `right: var(--toc-mobile-right, 1em)`
 - `aside.toc.mobile > nav`
   - `width: var(--toc-mobile-width, 12em)`
   - `background-color: var(--toc-mobile-bg, white)`: Background color of the `nav` element hovering in the lower-left screen corner when the ToC was opened on mobile screens.

--- a/src/app.css
+++ b/src/app.css
@@ -2,20 +2,17 @@
   --bg: #090019;
   --toc-mobile-bg: #484452;
   --toc-mobile-btn-color: white;
-  --toc-max-width: 15em;
-  --toc-active-padding: 2pt 4pt;
-  --toc-active-margin: 0 0 0 -4pt;
+  --toc-desktop-max-width: 15em;
 
   --ghc-color: var(--bg);
   --ghc-bg: white;
 }
 body {
   background: var(--bg);
-  padding: min(2em, 5vw);
+  padding: min(3em, 5vw);
   font-family: -apple-system, BlinkMacSystemFont, Roboto, sans-serif;
   margin: auto;
   color: #eee;
-  overflow-x: hidden;
 }
 /* outer div = hydration target */
 body > div {

--- a/src/routes/+page.svx
+++ b/src/routes/+page.svx
@@ -14,7 +14,7 @@
 
 </main>
 
-<Toc headingSelector="main :where(h2, h3)" activeTopOffset={200} />
+<Toc headingSelector="main :where(h2, h3)" activeHeadingScrollOffset={200} />
 
 <style>
   :global(h1) {

--- a/src/routes/long-page/+page.svx
+++ b/src/routes/long-page/+page.svx
@@ -538,4 +538,4 @@ Last but certainly not least, a big _**Thank You**_ to the contributors of VS Co
 
 </main>
 
-<Toc headingSelector="main :where(h2, h3, h4)" activeTopOffset={200} />
+<Toc headingSelector="main :where(h2, h3, h4)" activeHeadingScrollOffset={200} />


### PR DESCRIPTION
Closes #22.

@oskar-gmerek Could you try the code in this branch (e.g. by copy-pasting the [`Toc.svelte` component](https://github.com/janosh/svelte-toc/blob/5000f98e2ae2abdaf84c77c8d5035688b70f842e/src/lib/Toc.svelte) into your `node_modules`) to see if it solves the first problem reported in #22.