### PR TITLE
Replace style props with prop bags and heading data API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -201,37 +201,37 @@ Full list of props and bindable variables for this component (all of them option
    What to use as ARIA label for the button shown on mobile screens to open the ToC. Not used on desktop screens.
 
 1. ```ts
-   asideProps: HTMLAttributes<HTMLElementTagNameMap[`aside`]> = {}
+   asideProps: SvelteHTMLElements[`aside`] = {}
    ```
 
    Props passed to the outer `<aside>` element. Use this for custom classes, styles, ARIA attributes, and data attributes. Required ToC classes and managed attributes still take precedence.
 
 1. ```ts
-   navProps: HTMLAttributes<HTMLElementTagNameMap[`nav`]> = {}
+   navProps: SvelteHTMLElements[`nav`] = {}
    ```
 
    Props passed to the `<nav>` element wrapping the ToC title and list.
 
 1. ```ts
-   titleProps: HTMLAttributes<HTMLHeadingElement> = {}
+   titleProps: SvelteHTMLElements[`h2`] = {}
    ```
 
    Props passed to the default title `<h2>`. Has no effect when using `titleSnippet`.
 
 1. ```ts
-   olProps: HTMLAttributes<HTMLOListElement> = {}
+   olProps: SvelteHTMLElements[`ol`] = {}
    ```
 
    Props passed to the ToC `<ol>` element.
 
 1. ```ts
-   liProps: HTMLAttributes<HTMLLIElement> = {}
+   liProps: SvelteHTMLElements[`li`] = {}
    ```
 
    Props passed to every rendered ToC `<li>` item. Internal role, focus, active/collapsed classes, and generated indentation styles are preserved.
 
 1. ```ts
-   openButtonProps: HTMLAttributes<HTMLButtonElement> = {}
+   openButtonProps: SvelteHTMLElements[`button`] = {}
    ```
 
    Props passed to the mobile open button. The internal click handler and `openButtonLabel` ARIA label still take precedence.

--- a/readme.md
+++ b/readme.md
@@ -104,22 +104,14 @@ Full list of props and bindable variables for this component (all of them option
    ```
 
 1. ```ts
-   getHeadingIds = (node: HTMLHeadingElement): string => node.id
+   getHeadingData = (node: HTMLHeadingElement): TocHeadingData | null => ({
+     id: node.id,
+     level: Number(node.nodeName[1]),
+     title: node.textContent ?? ``,
+   })
    ```
 
-   Function that receives each DOM node matching `headingSelector` and returns the string to set the URL hash to when clicking the associated ToC entry. Set to `null` to prevent updating the URL hash on ToC clicks if e.g. your headings don't have IDs.
-
-1. ```ts
-   getHeadingLevels = (node: HTMLHeadingElement): number => Number(node.nodeName[1]) // get the number from H1, H2, ...
-   ```
-
-   Function that receives each DOM node matching `headingSelector` and returns an integer from 1 to 6 for the ToC depth (determines indentation and font-size).
-
-1. ```ts
-   getHeadingTitles = (node: HTMLHeadingElement): string => node.textContent ?? ``
-   ```
-
-   Function that receives each DOM node matching `headingSelector` and returns the string to display in the TOC.
+   Function that receives each DOM node matching `headingSelector` and returns the data used for the URL hash, ToC depth, and displayed ToC text. Return `null` to exclude a matched heading.
 
 1. ```ts
    headings: HTMLHeadingElement[] = []
@@ -204,7 +196,15 @@ Full list of props and bindable variables for this component (all of them option
    asideProps: SvelteHTMLElements[`aside`] = {}
    ```
 
-   Props passed to the outer `<aside>` element. Use this for custom classes, styles, ARIA attributes, and data attributes. Required ToC classes and managed attributes still take precedence.
+   Element prop bags spread user props first, then ToC-managed attributes take precedence where needed. Classes are combined with internal classes, and user styles pass through except for generated ToC item indentation/font-size styles. User event handlers run before internal handlers; call `event.preventDefault()` to skip the internal behavior.
+
+   TypeScript users can import `SvelteHTMLElements` from `svelte/elements` to type these prop bags.
+
+   ```ts
+   import type { SvelteHTMLElements } from 'svelte/elements'
+   ```
+
+   Props passed to the outer `<aside>` element. Use this for custom classes, styles, ARIA attributes, and data attributes.
 
 1. ```ts
    navProps: SvelteHTMLElements[`nav`] = {}
@@ -234,7 +234,7 @@ Full list of props and bindable variables for this component (all of them option
    openButtonProps: SvelteHTMLElements[`button`] = {}
    ```
 
-   Props passed to the mobile open button. The internal click handler and `openButtonLabel` ARIA label still take precedence.
+   Props passed to the mobile open button. `openButtonLabel` still controls the ARIA label.
 
    ```svelte
    <Toc
@@ -274,7 +274,7 @@ Full list of props and bindable variables for this component (all of them option
    Array of rendered ToC list item (`<li>`) DOM nodes. Headings are discovered with `document.querySelectorAll(headingSelector)`, filtered by `excludeSelector`, and rendered into these list items. Use `bind:tocItems` to access the rendered ToC items for DOM manipulation or event handling.
 
 1. ```ts
-   warnOnEmpty: boolean = true
+   warnOnEmpty: boolean = false
    ```
 
    Whether to issue a console warning if the ToC is empty.

--- a/readme.md
+++ b/readme.md
@@ -201,6 +201,49 @@ Full list of props and bindable variables for this component (all of them option
    What to use as ARIA label for the button shown on mobile screens to open the ToC. Not used on desktop screens.
 
 1. ```ts
+   asideProps: HTMLAttributes<HTMLElementTagNameMap[`aside`]> = {}
+   ```
+
+   Props passed to the outer `<aside>` element. Use this for custom classes, styles, ARIA attributes, and data attributes. Required ToC classes and managed attributes still take precedence.
+
+1. ```ts
+   navProps: HTMLAttributes<HTMLElementTagNameMap[`nav`]> = {}
+   ```
+
+   Props passed to the `<nav>` element wrapping the ToC title and list.
+
+1. ```ts
+   titleProps: HTMLAttributes<HTMLHeadingElement> = {}
+   ```
+
+   Props passed to the default title `<h2>`. Has no effect when using `titleSnippet`.
+
+1. ```ts
+   olProps: HTMLAttributes<HTMLOListElement> = {}
+   ```
+
+   Props passed to the ToC `<ol>` element.
+
+1. ```ts
+   liProps: HTMLAttributes<HTMLLIElement> = {}
+   ```
+
+   Props passed to every rendered ToC `<li>` item. Internal role, focus, active/collapsed classes, and generated indentation styles are preserved.
+
+1. ```ts
+   openButtonProps: HTMLAttributes<HTMLButtonElement> = {}
+   ```
+
+   Props passed to the mobile open button. The internal click handler and `openButtonLabel` ARIA label still take precedence.
+
+   ```svelte
+   <Toc
+     asideProps={{ class: `right-sidebar`, style: `width: 20em;` }}
+     liProps={{ class: `toc-item`, style: `padding-left: 10px;` }}
+   />
+   ```
+
+1. ```ts
    onOpenChange: OpenChangeHandler
    ```
 

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte'
   import { untrack } from 'svelte'
-  import type { HTMLAttributes, SVGAttributes } from 'svelte/elements'
+  import type { SVGAttributes, SvelteHTMLElements } from 'svelte/elements'
   import { blur, type BlurParams } from 'svelte/transition'
   import type { CollapseMode, OpenChangeHandler, OpenChangeTrigger } from './index'
 
@@ -83,14 +83,14 @@
     titleSnippet?: Snippet
     tocItem?: Snippet<[HTMLHeadingElement]>
     onOpenChange?: OpenChangeHandler
-    asideProps?: HTMLAttributes<HTMLElementTagNameMap[`aside`]>
-    navProps?: HTMLAttributes<HTMLElementTagNameMap[`nav`]>
-    titleProps?: HTMLAttributes<HTMLHeadingElement>
-    olProps?: HTMLAttributes<HTMLOListElement>
-    liProps?: HTMLAttributes<HTMLLIElement>
-    openButtonProps?: HTMLAttributes<HTMLButtonElement>
+    asideProps?: SvelteHTMLElements[`aside`]
+    navProps?: SvelteHTMLElements[`nav`]
+    titleProps?: SvelteHTMLElements[`h2`]
+    olProps?: SvelteHTMLElements[`ol`]
+    liProps?: SvelteHTMLElements[`li`]
+    openButtonProps?: SvelteHTMLElements[`button`]
     openButtonIconProps?: SVGAttributes<SVGSVGElement>
-  } & HTMLAttributes<HTMLElementTagNameMap[`aside`]> = $props()
+  } & SvelteHTMLElements[`aside`] = $props()
 
   let window_width: number = $state(0)
   // page_has_scrolled controls ignoring spurious scrollend events on page load before any actual
@@ -470,7 +470,7 @@
 <aside
   {...rest}
   {...asideProps}
-  class="toc {asideProps.class ?? null}"
+  class={[`toc`, asideProps.class]}
   class:collapsible={collapseSubheadings}
   class:desktop
   class:hidden={hide}
@@ -516,7 +516,7 @@
       {:else if title}
         <h2
           {...titleProps}
-          class="toc-title toc-exclude {titleProps.class ?? null}"
+          class={[`toc-title`, `toc-exclude`, titleProps.class]}
           style={titleProps.style ?? null}
         >
           {title}

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -38,18 +38,12 @@
     titleSnippet,
     tocItem,
     onOpenChange,
-    asideStyle = ``,
-    asideClass = ``,
-    navStyle = ``,
-    navClass = ``,
-    titleElementStyle = ``,
-    titleElementClass = ``,
-    olStyle = ``,
-    olClass = ``,
-    liStyle = ``,
-    liClass = ``,
-    openButtonStyle = ``,
-    openButtonClass = ``,
+    asideProps = {},
+    navProps = {},
+    titleProps = {},
+    olProps = {},
+    liProps = {},
+    openButtonProps = {},
     openButtonIconProps = {},
     ...rest
   }: {
@@ -89,18 +83,12 @@
     titleSnippet?: Snippet
     tocItem?: Snippet<[HTMLHeadingElement]>
     onOpenChange?: OpenChangeHandler
-    asideStyle?: string
-    asideClass?: string
-    navStyle?: string
-    navClass?: string
-    titleElementStyle?: string
-    titleElementClass?: string
-    olStyle?: string
-    olClass?: string
-    liStyle?: string
-    liClass?: string
-    openButtonStyle?: string
-    openButtonClass?: string
+    asideProps?: HTMLAttributes<HTMLElementTagNameMap[`aside`]>
+    navProps?: HTMLAttributes<HTMLElementTagNameMap[`nav`]>
+    titleProps?: HTMLAttributes<HTMLHeadingElement>
+    olProps?: HTMLAttributes<HTMLOListElement>
+    liProps?: HTMLAttributes<HTMLLIElement>
+    openButtonProps?: HTMLAttributes<HTMLButtonElement>
     openButtonIconProps?: SVGAttributes<SVGSVGElement>
   } & HTMLAttributes<HTMLElementTagNameMap[`aside`]> = $props()
 
@@ -481,7 +469,8 @@
 
 <aside
   {...rest}
-  class="toc {asideClass || null}"
+  {...asideProps}
+  class="toc {asideProps.class ?? null}"
   class:collapsible={collapseSubheadings}
   class:desktop
   class:hidden={hide}
@@ -490,18 +479,19 @@
   bind:this={aside}
   hidden={hide}
   aria-hidden={hide || intersecting}
-  style={asideStyle || null}
+  style={asideProps.style ?? null}
 >
   {#if !open && !desktop && headings.length >= minItems}
     <button
+      {...openButtonProps}
       onclick={(event) => {
         event.stopPropagation()
         event.preventDefault()
         set_open(true, `button`)
       }}
       aria-label={openButtonLabel}
-      class={openButtonClass || null}
-      style={openButtonStyle || null}
+      class={openButtonProps.class ?? null}
+      style={openButtonProps.style ?? null}
     >
       {#if openTocIcon}{@render openTocIcon()}{:else}
         <!-- https://iconify.design/icon-sets/heroicons-solid/menu.html -->
@@ -515,34 +505,42 @@
   {/if}
   {#if open || (desktop && headings.length >= minItems)}
     <nav
+      {...navProps}
       transition:blur={blurParams}
       bind:this={nav}
-      class={navClass || null}
-      style={navStyle || null}
+      class={navProps.class ?? null}
+      style={navProps.style ?? null}
     >
       {#if titleSnippet}
         {@render titleSnippet()}
       {:else if title}
         <h2
-          class="toc-title toc-exclude {titleElementClass || null}"
-          style={titleElementStyle || null}
+          {...titleProps}
+          class="toc-title toc-exclude {titleProps.class ?? null}"
+          style={titleProps.style ?? null}
         >
           {title}
         </h2>
       {/if}
-      <ol role="menu" class={olClass || null} style={olStyle || null}>
+      <ol
+        {...olProps}
+        role="menu"
+        class={olProps.class ?? null}
+        style={olProps.style ?? null}
+      >
         {#each headings as heading, idx (`${idx}-${heading.id}`)}
           {@const indent = levels[idx] - minLevel}
           {@const collapsed = collapseSubheadings && !heading_visibility[idx]}
           <li
+            {...liProps}
             role="menuitem"
             tabindex={collapsed ? -1 : 0}
             class:active={heading === activeHeading}
             class:collapsed
             aria-hidden={collapsed || undefined}
-            class={liClass || null}
+            class={liProps.class ?? null}
             bind:this={tocItems[idx]}
-            style={liStyle || null}
+            style={liProps.style ?? null}
             style:margin-left="calc({indent} * var(--toc-indent-per-level, 1em))"
             style:font-size="max(var(--toc-li-font-size-min, 2ex), calc(var(--toc-li-font-size-base, 3ex) - {indent} * var(--toc-li-font-size-step, 0.1ex)))"
             onclick={li_click_key_handler(heading)}

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -3,7 +3,12 @@
   import { untrack } from 'svelte'
   import type { SVGAttributes, SvelteHTMLElements } from 'svelte/elements'
   import { blur, type BlurParams } from 'svelte/transition'
-  import type { CollapseMode, OpenChangeHandler, OpenChangeTrigger } from './index'
+  import type {
+    CollapseMode,
+    OpenChangeHandler,
+    OpenChangeTrigger,
+    TocHeadingData,
+  } from './index'
 
   let {
     activeHeading = $bindable(null),
@@ -13,9 +18,11 @@
     breakpoint = 1000,
     desktop = $bindable(true),
     flashClickedHeadingsFor = 1500,
-    getHeadingIds = (node: HTMLHeadingElement): string => node.id,
-    getHeadingLevels = (node: HTMLHeadingElement): number => Number(node.nodeName[1]),
-    getHeadingTitles = (node: HTMLHeadingElement): string => node.textContent ?? ``,
+    getHeadingData = (node: HTMLHeadingElement): TocHeadingData => ({
+      id: node.id,
+      level: Number(node.nodeName[1]),
+      title: node.textContent ?? ``,
+    }),
     headings = $bindable([]),
     headingSelector = `:is(h2, h3, h4)`,
     excludeSelector = `.toc-exclude`,
@@ -45,7 +52,6 @@
     liProps = {},
     openButtonProps = {},
     openButtonIconProps = {},
-    ...rest
   }: {
     activeHeading?: HTMLHeadingElement | null
     activeHeadingScrollOffset?: number
@@ -54,9 +60,7 @@
     breakpoint?: number // in pixels (smaller window width is considered mobile, larger is desktop)
     desktop?: boolean
     flashClickedHeadingsFor?: number
-    getHeadingIds?: (node: HTMLHeadingElement) => string
-    getHeadingLevels?: (node: HTMLHeadingElement) => number
-    getHeadingTitles?: (node: HTMLHeadingElement) => string
+    getHeadingData?: (node: HTMLHeadingElement) => TocHeadingData | null
     // the result of document.querySelectorAll(headingSelector). can be useful for binding
     headings?: HTMLHeadingElement[]
     headingSelector?: string
@@ -90,7 +94,7 @@
     liProps?: SvelteHTMLElements[`li`]
     openButtonProps?: SvelteHTMLElements[`button`]
     openButtonIconProps?: SVGAttributes<SVGSVGElement>
-  } & SvelteHTMLElements[`aside`] = $props()
+  } = $props()
 
   let window_width: number = $state(0)
   // page_has_scrolled controls ignoring spurious scrollend events on page load before any actual
@@ -109,6 +113,7 @@
   let prev_scroll_target_distance: number = Infinity
   let last_invalid_selector_warning: string | null = null
   let last_reported_open: boolean | undefined = undefined
+  let heading_data: TocHeadingData[] = $state([])
 
   // helper to clear scroll_target state and cancel fallback timeout
   function clear_scroll_target() {
@@ -121,8 +126,10 @@
   }
 
   // helper to immediately set active heading and track scroll target
-  function set_scroll_target(node: HTMLHeadingElement) {
-    const idx = headings.indexOf(node)
+  function set_scroll_target(
+    node: HTMLHeadingElement,
+    idx = headings.indexOf(node),
+  ) {
     // only proceed if heading exists in array (could be removed between click and handler)
     if (idx < 0) return
     activeHeading = node
@@ -142,7 +149,11 @@
     onOpenChange?.({ open: value, desktop, trigger })
   }
 
-  let levels: number[] = $derived(headings.map(getHeadingLevels))
+  type LiEvent = (MouseEvent | KeyboardEvent) & {
+    currentTarget: EventTarget & HTMLLIElement
+  }
+
+  let levels: number[] = $derived(heading_data.map(({ level }) => level))
   let minLevel: number = $derived(Math.min(...levels) || 0)
 
   // Collapse threshold: true -> 6 (full nesting), 'h3' -> 3, false -> Infinity
@@ -273,12 +284,19 @@
 
     const new_headings = query_toc_headings()
     const invalid_selector = new_headings === null
+    const heading_entries = (new_headings ?? []).flatMap((heading) => {
+      const data = getHeadingData(heading)
+      return data === null ? [] : [{ data, heading }]
+    })
 
     // Use untrack to avoid creating dependencies on the state we're about to modify
     untrack(() => {
-      headings = new_headings ?? []
-      set_active_heading()
+      headings = heading_entries.map(({ heading }) => heading)
+      heading_data = heading_entries.map(({ data }) => data)
+      if (scroll_target && !headings.includes(scroll_target)) clear_scroll_target()
       if (headings.length === 0) {
+        activeHeading = null
+        activeTocLi = null
         if (warnOnEmpty && !invalid_selector) {
           const exclude_msg = excludeSelector
             ? ` after applying excludeSelector='${excludeSelector}'`
@@ -290,7 +308,10 @@
           )
         }
         if (autoHide) hide = true
-      } else if (hide && autoHide) hide = false
+      } else {
+        set_active_heading()
+        if (hide && autoHide) hide = false
+      }
     })
   }
 
@@ -312,6 +333,7 @@
   function set_active_heading() {
     // if we're in a programmatic scroll (click/keyboard initiated), keep the target active
     // until scrollend fires to prevent highlighting intermediate headings during smooth scroll
+    if (scroll_target && !headings.includes(scroll_target)) clear_scroll_target()
     if (scroll_target) {
       // detect if user manually scrolled away from scroll_target by checking if distance
       // is increasing (user scrolling away) rather than decreasing (smooth scroll in progress)
@@ -363,15 +385,20 @@
 
   // click and key handler for ToC items that scrolls to the heading
   const li_click_key_handler =
-    (node: HTMLHeadingElement) => (event: MouseEvent | KeyboardEvent) => {
+    (node: HTMLHeadingElement) => (event: LiEvent) => {
+      if (event instanceof KeyboardEvent) liProps.onkeydown?.(event)
+      else liProps.onclick?.(event)
+      if (event.defaultPrevented) return
       if (event instanceof KeyboardEvent && ![`Enter`, ` `].includes(event.key)) {
         return
       }
+      const idx = headings.indexOf(node)
+      if (idx < 0) return
       set_open(false, `toc-item`)
-      set_scroll_target(node) // immediately set active heading to prevent flicker during scroll
+      set_scroll_target(node, idx) // immediately set active heading to prevent flicker during scroll
       node.scrollIntoView?.({ behavior: scrollBehavior, block: `start` })
 
-      const id = getHeadingIds(node)
+      const id = heading_data[idx]?.id
       if (id) history.replaceState({}, ``, `#${id}`)
 
       if (flashClickedHeadingsFor) {
@@ -468,7 +495,6 @@
 />
 
 <aside
-  {...rest}
   {...asideProps}
   class={[`toc`, asideProps.class]}
   class:collapsible={collapseSubheadings}
@@ -485,6 +511,8 @@
     <button
       {...openButtonProps}
       onclick={(event) => {
+        openButtonProps.onclick?.(event)
+        if (event.defaultPrevented) return
         event.stopPropagation()
         event.preventDefault()
         set_open(true, `button`)
@@ -549,7 +577,7 @@
             {#if tocItem}
               {@render tocItem(heading)}
             {:else}
-              {getHeadingTitles(heading)}
+              {heading_data[idx]?.title}
             {/if}
           </li>
         {/each}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,3 +14,5 @@ export type OpenChangeEvent = {
   trigger: OpenChangeTrigger
 }
 export type OpenChangeHandler = (event: OpenChangeEvent) => void
+
+export type TocHeadingData = { id: string; level: number; title: string }

--- a/src/routes/(demos)/collapse-headings/+page.svelte
+++ b/src/routes/(demos)/collapse-headings/+page.svelte
@@ -169,7 +169,7 @@
 <Toc
   collapseSubheadings={collapse_mode}
   headingSelector=":is(h2, h3, h4, h5, h6)"
-  asideStyle="position: fixed; right: 9em; top: 6em; width: 22em;"
+  asideProps={{ style: `position: fixed; right: 9em; top: 6em; width: 22em;` }}
 />
 
 <style>

--- a/src/routes/(demos)/dynamic-headings/+page.svelte
+++ b/src/routes/(demos)/dynamic-headings/+page.svelte
@@ -26,7 +26,7 @@
     {/each}
   </main>
 
-  <Toc asideStyle="grid-column: 2;" />
+  <Toc asideProps={{ style: `grid-column: 2;` }} />
 </div>
 
 <style>

--- a/tests/vitest/readme.test.ts
+++ b/tests/vitest/readme.test.ts
@@ -2,7 +2,7 @@ import src from '$lib/Toc.svelte?raw'
 import readme from '$root/readme.md?raw'
 import { expect, test } from 'vitest'
 
-const props_block_regex = /}: \{([\s\S]*?)\}\s*&\s*[^\n=]+ = \$props\(\)/
+const props_block_regex = /}: \{([\s\S]*?)\}\s*(?:&\s*[^\n=]+)? = \$props\(\)/
 const prop_type_line_regex = /^\s+(\w+)\??:/
 const readme_prop_line_regex = /^\s+(\w+)/
 

--- a/tests/vitest/readme.test.ts
+++ b/tests/vitest/readme.test.ts
@@ -2,7 +2,7 @@ import src from '$lib/Toc.svelte?raw'
 import readme from '$root/readme.md?raw'
 import { expect, test } from 'vitest'
 
-const props_block_regex = /}: \{([\s\S]*?)\} & HTMLAttributes/
+const props_block_regex = /}: \{([\s\S]*?)\}\s*&\s*[^\n=]+ = \$props\(\)/
 const prop_type_line_regex = /^\s+(\w+)\??:/
 const readme_prop_line_regex = /^\s+(\w+)/
 
@@ -10,7 +10,7 @@ const readme_prop_line_regex = /^\s+(\w+)/
 const source_props = (props_block_regex.exec(src)?.[1] ?? ``)
   .split(`\n`)
   .map((line) => prop_type_line_regex.exec(line)?.[1])
-  .filter((x): x is string => Boolean(x))
+  .filter((prop): prop is string => Boolean(prop))
 
 // Extract prop names from readme (format: "1. ```ts\n   propName:")
 const readme_props = readme.split(`\n`).flatMap((line, idx, lines) => {
@@ -43,6 +43,18 @@ test.each(source_props.filter((p) => !separately_documented_props.has(p)))(
 
 test.each(readme_props)(`readme prop '%s' exists in Toc.svelte`, (prop) => {
   expect(source_props).toContain(prop)
+})
+
+test.each([
+  [`asideProps`, `SvelteHTMLElements[\`aside\`]`],
+  [`navProps`, `SvelteHTMLElements[\`nav\`]`],
+  [`titleProps`, `SvelteHTMLElements[\`h2\`]`],
+  [`olProps`, `SvelteHTMLElements[\`ol\`]`],
+  [`liProps`, `SvelteHTMLElements[\`li\`]`],
+  [`openButtonProps`, `SvelteHTMLElements[\`button\`]`],
+])(`types prop bag '%s' with tag-specific Svelte attributes`, (prop, expected_type) => {
+  expect(src).toContain(`${prop}?: ${expected_type}`)
+  expect(readme).toContain(`${prop}: ${expected_type} = {}`)
 })
 
 test.each(source_css_vars)(`readme documents CSS var '%s'`, (css_var) => {

--- a/tests/vitest/readme.test.ts
+++ b/tests/vitest/readme.test.ts
@@ -26,24 +26,15 @@ const extract_css_vars = (text: string) =>
 const source_css_vars = extract_css_vars(src)
 const readme_css_vars = extract_css_vars(readme)
 
-// Props intentionally not documented (snippets/style/class props)
-const style_class_props = [
-  `aside`,
-  `nav`,
-  `titleElement`,
-  `ol`,
-  `li`,
-  `openButton`,
-].flatMap((el) => [`${el}Style`, `${el}Class`])
-const undocumented_props = new Set([
+// Props documented outside the numbered props list.
+const separately_documented_props = new Set([
   `openTocIcon`,
   `titleSnippet`,
   `tocItem`,
-  ...style_class_props,
   `openButtonIconProps`,
 ])
 
-test.each(source_props.filter((p) => !undocumented_props.has(p)))(
+test.each(source_props.filter((p) => !separately_documented_props.has(p)))(
   `readme documents prop '%s'`,
   (prop) => {
     expect(readme_props).toContain(prop)

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -168,6 +168,30 @@ describe(`Toc`, () => {
     },
   )
 
+  test(`getHeadingData customizes listed headings`, async () => {
+    set_body(`<h2>Keep</h2><h3>Skip</h3>`)
+    const replace_state_mock = vi.spyOn(history, `replaceState`)
+    mount(Toc, {
+      target: document.body,
+      props: {
+        getHeadingData: (node: HTMLHeadingElement) =>
+          node.textContent === `Skip`
+            ? null
+            : { id: `custom`, level: 2, title: `Custom` },
+        headingSelector: `:is(h2, h3)`,
+      },
+    })
+    await tick()
+
+    const toc_items = document.querySelectorAll(`aside.toc li`)
+    expect(toc_items).toHaveLength(1)
+    const toc_item = toc_items[0]
+    expect(toc_item.textContent).toBe(`Custom`)
+
+    toc_item.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+    expect(replace_state_mock).toHaveBeenCalledWith({}, ``, `#custom`)
+  })
+
   test.each([
     [`headingSelector`, { headingSelector: `[` }],
     [`excludeSelector`, { excludeSelector: `[` }],
@@ -633,29 +657,39 @@ describe(`Toc`, () => {
     },
   )
 
-  test(`mutation observer updates ToC when heading is dynamically added`, async () => {
+  test(`mutation observer updates ToC when headings change`, async () => {
     document.body.innerHTML = `
       <div id="content">
-        <h2>Initial Heading</h2>
+        <h2 id="initial">Initial Heading</h2>
       </div>
     `
+    const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
+    Element.prototype.scrollIntoView = scroll_into_view_mock
 
     mount(Toc, { target: document.body })
     await tick()
 
     let toc_items = document.querySelectorAll(`aside.toc > nav > ol > li`)
-    expect(toc_items.length).toBe(1)
+    expect(toc_items).toHaveLength(1)
     expect(toc_items[0].textContent.trim()).toBe(`Initial Heading`)
+    const stale_item = toc_items[0]
 
     const new_heading = document.createElement(`h3`)
     new_heading.textContent = `Dynamically Added Heading`
-    document.querySelector(`#content`)?.append(new_heading)
+    doc_query(`#content`).append(new_heading)
 
     await tick()
 
     toc_items = document.querySelectorAll(`aside.toc > nav > ol > li`)
-    expect(toc_items.length).toBe(2)
+    expect(toc_items).toHaveLength(2)
     expect(toc_items[1].textContent.trim()).toBe(`Dynamically Added Heading`)
+
+    doc_query(`#initial`).remove()
+    await tick()
+    expect(doc_query(`aside.toc ol li`).textContent).toBe(`Dynamically Added Heading`)
+
+    stale_item.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+    expect(scroll_into_view_mock).not.toHaveBeenCalled()
   })
 
   // Tests for issue #50: scroll_target prevents flicker during programmatic scrolling
@@ -726,6 +760,20 @@ describe(`Toc`, () => {
       globalThis.dispatchEvent(new Event(`scroll`))
       await tick()
       // JSDOM: all getBoundingClientRect return 0, so last heading becomes active
+      expect(active_text()).toBe(`Heading 3`)
+    })
+
+    test(`removing scroll target activates a remaining heading`, async () => {
+      mount(Toc, { target: document.body, props: { open: true } })
+      await tick()
+
+      doc_query(`aside.toc ol li`).click()
+      await tick()
+      expect(active_text()).toBe(`Heading 1`)
+
+      doc_query(`#heading-1`).remove()
+      await tick()
+
       expect(active_text()).toBe(`Heading 3`)
     })
 
@@ -967,8 +1015,6 @@ describe(`Element Prop Bags`, () => {
         class: [`custom-aside-class`, { 'custom-aside-object-class': true }],
         style: `color: rgb(255, 0, 0);`,
         'data-testid': `toc-aside`,
-        hidden: false,
-        'aria-hidden': `false`,
       },
       extra_props: { hide: true, autoHide: false },
       selector: `aside.toc`,
@@ -1008,7 +1054,6 @@ describe(`Element Prop Bags`, () => {
         class: `custom-ol-class`,
         style: `list-style-type: square;`,
         'data-testid': `toc-list`,
-        role: `list`,
         start: 3,
         reversed: true,
       },
@@ -1024,13 +1069,13 @@ describe(`Element Prop Bags`, () => {
         class: `custom-li-class`,
         style: `padding-left: 10px;`,
         'data-testid': `toc-item`,
-        role: `presentation`,
-        tabindex: -1,
+        onclick: vi.fn<() => void>(),
         value: 7,
       },
       selector: `aside.toc nav ol li`,
       expected_classes: [`active`, `custom-li-class`],
       expected_attributes: { role: `menuitem`, tabindex: `0`, value: `7` },
+      expected_open_changes: 0,
       setup: ensure_single_heading,
     },
     {
@@ -1040,9 +1085,8 @@ describe(`Element Prop Bags`, () => {
         class: `custom-button-class`,
         style: `border: 1px solid rgb(0, 128, 0);`,
         'data-testid': `toc-open-button`,
-        'aria-label': `Wrong label`,
         disabled: true,
-        onclick: vi.fn<() => void>(),
+        onclick: vi.fn<(event: MouseEvent) => void>((event) => event.preventDefault()),
         type: `button`,
       },
       extra_props: { desktop: false },
@@ -1053,6 +1097,7 @@ describe(`Element Prop Bags`, () => {
         disabled: ``,
         type: `button`,
       },
+      expected_open_changes: 0,
       setup: ensure_mobile_button_is_visible,
     },
   ]
@@ -1066,16 +1111,25 @@ describe(`Element Prop Bags`, () => {
       selector,
       expected_classes,
       expected_attributes = {},
+      expected_open_changes,
       setup,
     }) => {
       setup()
-      const blocked_click = `onclick` in bag ? bag.onclick : vi.fn<() => void>()
+      const has_user_click = `onclick` in bag
+      const user_click = has_user_click ? bag.onclick : vi.fn<() => void>()
+      const on_open_change = vi.fn<OpenChangeHandler>()
+      const expected_open_change_count = expected_open_changes ?? (has_user_click ? 1 : 0)
 
       mount(Toc, {
         target: document.body,
-        props: { ...extra_props, [prop_name]: bag },
+        props: {
+          ...extra_props,
+          ...(has_user_click ? { onOpenChange: on_open_change } : {}),
+          [prop_name]: bag,
+        },
       })
       await tick()
+      on_open_change.mockClear()
 
       const element = doc_query(selector)
       expect(element.getAttribute(`style`)).toContain(bag.style)
@@ -1087,10 +1141,13 @@ describe(`Element Prop Bags`, () => {
         expect(element.getAttribute(attribute)).toBe(value)
       }
       if (`onclick` in bag) {
-        element.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+        element.dispatchEvent(
+          new MouseEvent(`click`, { bubbles: true, cancelable: true }),
+        )
         await tick()
       }
-      expect(blocked_click).not.toHaveBeenCalled()
+      expect(user_click).toHaveBeenCalledTimes(has_user_click ? 1 : 0)
+      expect(on_open_change).toHaveBeenCalledTimes(expected_open_change_count)
     },
   )
 

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -958,179 +958,150 @@ describe(`hideOnIntersect`, () => {
   })
 })
 
-describe(`Style and Class Props Application`, () => {
-  const test_cases = [
-    // Aside tests
+describe(`Element Prop Bags`, () => {
+  const prop_bag_cases = [
     {
-      elementName: `aside`,
-      propName: `asideStyle`,
-      value: `color: rgb(255, 0, 0);`,
+      element_name: `aside`,
+      prop_name: `asideProps`,
+      bag: {
+        class: `custom-aside-class`,
+        style: `color: rgb(255, 0, 0);`,
+        'data-testid': `toc-aside`,
+        hidden: false,
+        'aria-hidden': `false`,
+      },
+      extra_props: { hide: true, autoHide: false },
       selector: `aside.toc`,
-      check: `style`,
-      setupFn: ensure_content_for_toc_elements,
+      required_classes: [`toc`],
+      expected_attributes: { hidden: ``, 'aria-hidden': `true` },
+      setup: ensure_content_for_toc_elements,
     },
     {
-      elementName: `aside`,
-      propName: `asideClass`,
-      value: `custom-aside-class`,
-      selector: `aside.toc`,
-      check: `class`,
-      setupFn: ensure_content_for_toc_elements,
-    },
-    // Nav tests
-    {
-      elementName: `nav`,
-      propName: `navStyle`,
-      value: `background-color: rgb(0, 0, 255);`,
+      element_name: `nav`,
+      prop_name: `navProps`,
+      bag: {
+        class: `custom-nav-class`,
+        style: `background-color: rgb(0, 0, 255);`,
+        'data-testid': `toc-nav`,
+      },
       selector: `aside.toc nav`,
-      check: `style`,
-      setupFn: ensure_content_for_toc_elements,
-      extraProps: { title: `Test Title` }, // Nav needs title or items to render
+      required_classes: [],
+      setup: ensure_content_for_toc_elements,
     },
     {
-      elementName: `nav`,
-      propName: `navClass`,
-      value: `custom-nav-class`,
-      selector: `aside.toc nav`,
-      check: `class`,
-      setupFn: ensure_content_for_toc_elements,
-      extraProps: { title: `Test Title` },
-    },
-    // Title element tests
-    {
-      elementName: `title`,
-      propName: `titleElementStyle`,
-      value: `font-style: italic;`,
+      element_name: `title`,
+      prop_name: `titleProps`,
+      bag: {
+        class: `custom-title-class`,
+        style: `font-style: italic;`,
+        'data-testid': `toc-title`,
+      },
+      extra_props: { title: `Test Custom Title` },
       selector: `aside.toc nav .toc-title`,
-      check: `style`,
-      setupFn: ensure_content_for_toc_elements,
-      extraProps: { title: `Test Custom Title` },
+      required_classes: [`toc-title`, `toc-exclude`],
+      setup: ensure_content_for_toc_elements,
     },
     {
-      elementName: `title`,
-      propName: `titleElementClass`,
-      value: `custom-title-class`,
-      selector: `aside.toc nav .toc-title`,
-      check: `class`,
-      setupFn: ensure_content_for_toc_elements,
-      extraProps: { title: `Test Custom Title` },
-      additionalClassChecks: [`toc-title`, `toc-exclude`],
-    },
-    // OL tests
-    {
-      elementName: `ol`,
-      propName: `olStyle`,
-      value: `list-style-type: square;`,
+      element_name: `ol`,
+      prop_name: `olProps`,
+      bag: {
+        class: `custom-ol-class`,
+        style: `list-style-type: square;`,
+        'data-testid': `toc-list`,
+        role: `list`,
+      },
       selector: `aside.toc nav ol`,
-      check: `style`,
-      setupFn: ensure_content_for_toc_elements,
+      required_classes: [],
+      expected_attributes: { role: `menu` },
+      setup: ensure_content_for_toc_elements,
     },
     {
-      elementName: `ol`,
-      propName: `olClass`,
-      value: `custom-ol-class`,
-      selector: `aside.toc nav ol`,
-      check: `class`,
-      setupFn: ensure_content_for_toc_elements,
-    },
-    // LI tests
-    {
-      elementName: `li`,
-      propName: `liStyle`,
-      value: `padding-left: 10px;`,
+      element_name: `li`,
+      prop_name: `liProps`,
+      bag: {
+        class: `custom-li-class`,
+        style: `padding-left: 10px;`,
+        'data-testid': `toc-item`,
+        role: `presentation`,
+        tabindex: -1,
+      },
       selector: `aside.toc nav ol li`,
-      check: `style`,
-      setupFn: ensure_single_heading,
+      required_classes: [`active`],
+      expected_attributes: { role: `menuitem`, tabindex: `0` },
+      setup: ensure_single_heading,
     },
     {
-      elementName: `li`,
-      propName: `liClass`,
-      value: `custom-li-class`,
-      selector: `aside.toc nav ol li`,
-      check: `class`,
-      setupFn: ensure_single_heading,
-    },
-    // Open button tests
-    {
-      elementName: `open button`,
-      propName: `openButtonStyle`,
-      value: `border: 1px solid rgb(0, 128, 0);`,
+      element_name: `open button`,
+      prop_name: `openButtonProps`,
+      bag: {
+        class: `custom-button-class`,
+        style: `border: 1px solid rgb(0, 128, 0);`,
+        'data-testid': `toc-open-button`,
+        'aria-label': `Wrong label`,
+      },
+      extra_props: { desktop: false },
       selector: `aside.toc > button`,
-      check: `style`,
-      setupFn: ensure_mobile_button_is_visible,
-      extraProps: { desktop: false }, // Ensure button context
-    },
-    {
-      elementName: `open button`,
-      propName: `openButtonClass`,
-      value: `custom-button-class`,
-      selector: `aside.toc > button`,
-      check: `class`,
-      setupFn: ensure_mobile_button_is_visible,
-      extraProps: { desktop: false },
+      required_classes: [],
+      expected_attributes: { 'aria-label': `Open table of contents` },
+      blocks_user_click: true,
+      setup: ensure_mobile_button_is_visible,
     },
   ]
 
-  const style_cases = test_cases.filter((tc) => tc.check === `style`)
-  const class_cases = test_cases.filter((tc) => tc.check === `class`)
-
-  test.each(style_cases)(
-    `applies $propName style to $elementName element`,
-    async ({ propName, value, selector, setupFn, extraProps = {} }) => {
-      setupFn()
+  test.each(prop_bag_cases)(
+    `applies $element_name prop bag attributes`,
+    async ({
+      prop_name,
+      bag,
+      extra_props = {},
+      selector,
+      required_classes,
+      expected_attributes = {},
+      blocks_user_click = false,
+      setup,
+    }) => {
+      setup()
+      const user_click = vi.fn<() => void>()
+      const actual_bag = blocks_user_click ? { ...bag, onclick: user_click } : bag
 
       mount(Toc, {
         target: document.body,
-        props: { ...extraProps, [propName]: value },
+        props: { ...extra_props, [prop_name]: actual_bag },
       })
       await tick()
 
       const element = doc_query(selector)
-      const style_attribute = element.getAttribute(`style`)
-      expect(style_attribute).not.toBeNull()
-      expect(style_attribute).toContain(value)
+      expect(element.getAttribute(`style`)).toContain(bag.style)
+      expect(element.classList.contains(bag.class)).toBe(true)
+      expect(element.getAttribute(`data-testid`)).toBe(bag[`data-testid`])
+      for (const cls of required_classes) {
+        expect(element.classList.contains(cls)).toBe(true)
+      }
+      for (const [attribute, value] of Object.entries(expected_attributes)) {
+        expect(element.getAttribute(attribute)).toBe(value)
+      }
+      if (blocks_user_click) {
+        element.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+        await tick()
+      }
+      expect(user_click).not.toHaveBeenCalled()
     },
   )
 
-  test(`liStyle preserves existing margin-left and font-size styles`, async () => {
+  test(`liProps.style preserves generated margin-left and font-size styles`, async () => {
     ensure_content_for_toc_elements([`<h2>Single Heading</h2>`])
 
     mount(Toc, {
       target: document.body,
-      props: { liStyle: `padding-left: 10px;` },
+      props: { liProps: { style: `padding-left: 10px;` } },
     })
     await tick()
 
     const style_attribute = doc_query(`aside.toc nav ol li`).getAttribute(`style`)
+    expect(style_attribute).toContain(`padding-left: 10px;`)
     expect(style_attribute).toContain(`margin-left`)
     expect(style_attribute).toContain(`font-size`)
   })
-
-  test.each(class_cases)(
-    `applies $propName class to $elementName element`,
-    async ({
-      propName,
-      value,
-      selector,
-      setupFn,
-      extraProps = {},
-      additionalClassChecks = [],
-    }) => {
-      setupFn()
-
-      mount(Toc, {
-        target: document.body,
-        props: { ...extraProps, [propName]: value },
-      })
-      await tick()
-
-      const element = doc_query(selector)
-      expect(element.classList.contains(value)).toBe(true)
-      for (const cls of additionalClassChecks) {
-        expect(element.classList.contains(cls)).toBe(true)
-      }
-    },
-  )
 
   test.each([
     {

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -964,7 +964,7 @@ describe(`Element Prop Bags`, () => {
       element_name: `aside`,
       prop_name: `asideProps`,
       bag: {
-        class: `custom-aside-class`,
+        class: [`custom-aside-class`, { 'custom-aside-object-class': true }],
         style: `color: rgb(255, 0, 0);`,
         'data-testid': `toc-aside`,
         hidden: false,
@@ -972,7 +972,7 @@ describe(`Element Prop Bags`, () => {
       },
       extra_props: { hide: true, autoHide: false },
       selector: `aside.toc`,
-      required_classes: [`toc`],
+      expected_classes: [`toc`, `custom-aside-class`, `custom-aside-object-class`],
       expected_attributes: { hidden: ``, 'aria-hidden': `true` },
       setup: ensure_content_for_toc_elements,
     },
@@ -985,20 +985,20 @@ describe(`Element Prop Bags`, () => {
         'data-testid': `toc-nav`,
       },
       selector: `aside.toc nav`,
-      required_classes: [],
+      expected_classes: [`custom-nav-class`],
       setup: ensure_content_for_toc_elements,
     },
     {
       element_name: `title`,
       prop_name: `titleProps`,
       bag: {
-        class: `custom-title-class`,
+        class: { 'custom-title-class': true },
         style: `font-style: italic;`,
         'data-testid': `toc-title`,
       },
       extra_props: { title: `Test Custom Title` },
       selector: `aside.toc nav .toc-title`,
-      required_classes: [`toc-title`, `toc-exclude`],
+      expected_classes: [`toc-title`, `toc-exclude`, `custom-title-class`],
       setup: ensure_content_for_toc_elements,
     },
     {
@@ -1009,10 +1009,12 @@ describe(`Element Prop Bags`, () => {
         style: `list-style-type: square;`,
         'data-testid': `toc-list`,
         role: `list`,
+        start: 3,
+        reversed: true,
       },
       selector: `aside.toc nav ol`,
-      required_classes: [],
-      expected_attributes: { role: `menu` },
+      expected_classes: [`custom-ol-class`],
+      expected_attributes: { role: `menu`, start: `3`, reversed: `` },
       setup: ensure_content_for_toc_elements,
     },
     {
@@ -1024,10 +1026,11 @@ describe(`Element Prop Bags`, () => {
         'data-testid': `toc-item`,
         role: `presentation`,
         tabindex: -1,
+        value: 7,
       },
       selector: `aside.toc nav ol li`,
-      required_classes: [`active`],
-      expected_attributes: { role: `menuitem`, tabindex: `0` },
+      expected_classes: [`active`, `custom-li-class`],
+      expected_attributes: { role: `menuitem`, tabindex: `0`, value: `7` },
       setup: ensure_single_heading,
     },
     {
@@ -1038,12 +1041,18 @@ describe(`Element Prop Bags`, () => {
         style: `border: 1px solid rgb(0, 128, 0);`,
         'data-testid': `toc-open-button`,
         'aria-label': `Wrong label`,
+        disabled: true,
+        onclick: vi.fn<() => void>(),
+        type: `button`,
       },
       extra_props: { desktop: false },
       selector: `aside.toc > button`,
-      required_classes: [],
-      expected_attributes: { 'aria-label': `Open table of contents` },
-      blocks_user_click: true,
+      expected_classes: [`custom-button-class`],
+      expected_attributes: {
+        'aria-label': `Open table of contents`,
+        disabled: ``,
+        type: `button`,
+      },
       setup: ensure_mobile_button_is_visible,
     },
   ]
@@ -1055,36 +1064,33 @@ describe(`Element Prop Bags`, () => {
       bag,
       extra_props = {},
       selector,
-      required_classes,
+      expected_classes,
       expected_attributes = {},
-      blocks_user_click = false,
       setup,
     }) => {
       setup()
-      const user_click = vi.fn<() => void>()
-      const actual_bag = blocks_user_click ? { ...bag, onclick: user_click } : bag
+      const blocked_click = `onclick` in bag ? bag.onclick : vi.fn<() => void>()
 
       mount(Toc, {
         target: document.body,
-        props: { ...extra_props, [prop_name]: actual_bag },
+        props: { ...extra_props, [prop_name]: bag },
       })
       await tick()
 
       const element = doc_query(selector)
       expect(element.getAttribute(`style`)).toContain(bag.style)
-      expect(element.classList.contains(bag.class)).toBe(true)
       expect(element.getAttribute(`data-testid`)).toBe(bag[`data-testid`])
-      for (const cls of required_classes) {
+      for (const cls of expected_classes) {
         expect(element.classList.contains(cls)).toBe(true)
       }
       for (const [attribute, value] of Object.entries(expected_attributes)) {
         expect(element.getAttribute(attribute)).toBe(value)
       }
-      if (blocks_user_click) {
+      if (`onclick` in bag) {
         element.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
         await tick()
       }
-      expect(user_click).not.toHaveBeenCalled()
+      expect(blocked_click).not.toHaveBeenCalled()
     },
   )
 


### PR DESCRIPTION
## Summary
- Replace scalar style/class customization props with element prop bags for rendered ToC elements.
- Consolidate heading id, level, and title customization into `getHeadingData`, including support for filtering headings by returning `null`.
- Compose user event handlers with internal ToC behavior so `event.preventDefault()` can opt out of internal clicks/keyboard handling.
- Update demos, README docs, and Vitest coverage for the breaking customization API changes.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run tests/vitest/toc.svelte.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Component props API restructured: new prop objects replace individual style/class props
  * Heading customization simplified via unified callback

* **Documentation**
  * Updated component documentation with new API examples and prop references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janosh/svelte-toc/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->