### PR TITLE
Improve Toc interactions and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
   "peerDependencies": {
     "svelte": "^5.0.0"
   },
-  "packageManager": "pnpm@11.5.0"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/readme.md
+++ b/readme.md
@@ -391,7 +391,7 @@ The HTML structure of this component is
   - `transition: var(--toc-li-transition)`: Custom transition for hover/focus effects.
   - `max-height: var(--toc-li-max-height, 10em)`: Used for collapse animation.
   - `transition: ... var(--toc-collapse-duration, 0.2s) ...`: Duration for collapse/expand animation.
-- `aside.toc > nav > ol > li:focus-visible`
+- `aside.toc > nav > ol > li > a:focus-visible`, `aside.toc > nav > ol > li:focus-visible`
   - `outline: var(--toc-focus-outline, 2px solid currentColor)`: Focus outline for keyboard navigation.
   - `outline-offset: var(--toc-focus-outline-offset, 1px)`
 - `aside.toc > nav > ol > li:hover`

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -10,11 +10,7 @@
     SlugifyHeading,
     TocHeadingData,
   } from './index'
-  import {
-    get_heading_visibility,
-    slugify_heading_text,
-    unique_id,
-  } from './toc-utils'
+  import { get_heading_visibility, slugify_heading_text, unique_id } from './toc-utils'
 
   let {
     activeHeading = $bindable(null),
@@ -111,15 +107,10 @@
   const scroll_target_fallback_ms = 1000
   // distance increase (px) that counts as the user manually scrolling away from a target
   const manual_scroll_threshold_px = 50
-  const custom_interactive_selector =
-    `a, button, input, select, textarea, summary, [role="button"], [role="link"], [tabindex]`
+  const custom_interactive_selector = `a, button, input, select, textarea, summary, [role="button"], [role="link"], [tabindex]`
   const is_activation_key = (key: string) => key === `Enter` || key === ` `
   const is_modified_click = (event: MouseEvent) =>
-    event.button !== 0 ||
-    event.metaKey ||
-    event.ctrlKey ||
-    event.shiftKey ||
-    event.altKey
+    event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey
 
   let window_width: number = $state(0)
   // page_has_scrolled controls ignoring spurious scrollend events on page load before any actual
@@ -152,10 +143,7 @@
   }
 
   // helper to immediately set active heading and track scroll target
-  function set_scroll_target(
-    node: HTMLHeadingElement,
-    idx = headings.indexOf(node),
-  ) {
+  function set_scroll_target(node: HTMLHeadingElement, idx = headings.indexOf(node)) {
     // only proceed if heading exists in array (could be removed between click and handler)
     if (idx < 0) return
     activeHeading = node
@@ -181,29 +169,27 @@
   function event_targets_custom_interactive(event: LiEvent) {
     if (!tocItem || !(event.target instanceof Element)) return false
     // only bypass scroll-to-heading when the event lands on an interactive element
-    // nested *inside* the li; the li itself matches the selector (role=link/tabindex)
-    // and must not count, so compare against currentTarget
+    // nested *inside* the li; fallback li semantics must not count as custom content
     const interactive = event.target.closest(custom_interactive_selector)
     return interactive !== null && interactive !== event.currentTarget
   }
 
   let levels: number[] = $derived(heading_data.map(({ level }) => level))
-  let minLevel: number = $derived(levels.length ? Math.min(...levels) : 0)
+  let min_level: number = $derived(levels.length ? Math.min(...levels) : 0)
 
   // Collapse threshold: true -> 6 (full nesting), 'h3' -> 3, false -> Infinity
   let collapse_threshold: number = $derived(
     collapseSubheadings === true
       ? 6
       : typeof collapseSubheadings === `string`
-      ? parseInt(collapseSubheadings.slice(1), 10)
-      : Infinity,
+        ? parseInt(collapseSubheadings.slice(1), 10)
+        : Infinity,
   )
 
   // Memoized visibility array - computed once per render cycle
   let heading_visibility: boolean[] = $derived.by(() => {
-    const active_idx = collapseSubheadings && activeHeading
-      ? headings.indexOf(activeHeading)
-      : null
+    const active_idx =
+      collapseSubheadings && activeHeading ? headings.indexOf(activeHeading) : null
     return get_heading_visibility(levels, active_idx, collapse_threshold)
   })
 
@@ -247,8 +233,27 @@
   }
 
   function focus_toc_item(node: HTMLLIElement | null) {
-    const focus_target = node?.querySelector<HTMLAnchorElement>(`a`) ?? node
+    const focus_target = first_custom_interactive(node) ?? node
     focus_target?.focus({ preventScroll: true })
+  }
+
+  function first_custom_interactive(node: HTMLLIElement | null) {
+    return node?.querySelector<HTMLElement>(custom_interactive_selector) ?? null
+  }
+
+  function focus_is_in_custom_interactive_toc_item() {
+    if (!tocItem || !(document.activeElement instanceof HTMLElement)) return false
+    const current_toc_li = document.activeElement.closest<HTMLLIElement>(`li`)
+    const interactive = document.activeElement.closest<HTMLElement>(
+      custom_interactive_selector,
+    )
+    return (
+      current_toc_li !== null &&
+      nav?.contains(current_toc_li) === true &&
+      interactive !== null &&
+      interactive !== current_toc_li &&
+      current_toc_li.contains(interactive)
+    )
   }
 
   function href_for_id(id: string | undefined): string | undefined {
@@ -268,10 +273,7 @@
 
     if (flashClickedHeadingsFor) {
       node.classList.add(`toc-clicked`)
-      setTimeout(
-        () => node.classList.remove(`toc-clicked`),
-        flashClickedHeadingsFor,
-      )
+      setTimeout(() => node.classList.remove(`toc-clicked`), flashClickedHeadingsFor)
     }
   }
 
@@ -286,9 +288,10 @@
       document.querySelector(selector)
       selector_validity[key] = true
     } catch {
-      const fallback = selector_name === `hideOnIntersect`
-        ? `Ignoring selector.`
-        : `Showing empty table of contents.`
+      const fallback =
+        selector_name === `hideOnIntersect`
+          ? `Ignoring selector.`
+          : `Showing empty table of contents.`
       console.warn(
         `svelte-toc received invalid ${selector_name}='${selector}'. ${fallback}`,
       )
@@ -301,7 +304,8 @@
     if (
       !selector_is_valid(`headingSelector`, headingSelector) ||
       !selector_is_valid(`excludeSelector`, excludeSelector)
-    ) return null
+    )
+      return null
 
     return Array.from(
       document.querySelectorAll<HTMLHeadingElement>(headingSelector),
@@ -325,9 +329,15 @@
       if (record.type === `characterData`) {
         return element_matches_heading_selector(record.target.parentElement)
       }
-      if (record.type !== `attributes` || record.attributeName !== `id`) return false
-      return record.target instanceof Element &&
-        element_matches_heading_selector(record.target)
+      if (record.type !== `attributes` || !(record.target instanceof Element))
+        return false
+      const target = record.target
+      return (
+        selector_is_valid(`headingSelector`, headingSelector) &&
+        (target.closest(headingSelector) !== null ||
+          target.querySelector(headingSelector) !== null ||
+          headings.some((heading) => target.contains(heading)))
+      )
     })
   }
 
@@ -356,10 +366,12 @@
     const queried_headings = query_toc_headings()
     const invalid_selector = queried_headings === null
     let used_ids: Set<string> | undefined
-    const get_used_ids = () => used_ids ??= new Set(
-      Array.from(document.querySelectorAll<HTMLElement>(`[id]`), ({ id }) => id)
-        .filter(Boolean),
-    )
+    const get_used_ids = () =>
+      (used_ids ??= new Set(
+        Array.from(document.querySelectorAll<HTMLElement>(`[id]`), ({ id }) => id).filter(
+          Boolean,
+        ),
+      ))
     const heading_entries: { data: TocHeadingData; heading: HTMLHeadingElement }[] = []
     for (const [idx, heading] of (queried_headings ?? []).entries()) {
       const data = getHeadingData(heading)
@@ -373,11 +385,17 @@
     // Use untrack to avoid creating dependencies on the state we're about to modify
     untrack(() => {
       // skip state churn when an unrelated DOM mutation left the heading set unchanged
-      const unchanged = !invalid_selector && heading_entries.length > 0 &&
+      const unchanged =
+        !invalid_selector &&
+        heading_entries.length > 0 &&
         heading_entries.length === headings.length &&
-        heading_entries.every(({ heading, data }, idx) =>
-          heading === headings[idx] && data.id === heading_data[idx]?.id &&
-          data.level === heading_data[idx]?.level && data.title === heading_data[idx]?.title)
+        heading_entries.every(
+          ({ heading, data }, idx) =>
+            heading === headings[idx] &&
+            data.id === heading_data[idx]?.id &&
+            data.level === heading_data[idx]?.level &&
+            data.title === heading_data[idx]?.title,
+        )
       if (unchanged) return
 
       headings = heading_entries.map(({ heading }) => heading)
@@ -406,16 +424,21 @@
 
   $effect(update_toc_headings)
 
+  let toc_item_has_interactive = $derived(
+    tocItem
+      ? tocItems.map((toc_item) => Boolean(first_custom_interactive(toc_item)))
+      : [],
+  )
+
   $effect(() => {
     const observer = new MutationObserver((records) => {
       if (should_update_for_mutations(records)) update_toc_headings()
     })
 
-    // Configure the observer to watch for changes in the DOM structure
+    // Attribute changes can affect headingSelector/excludeSelector membership.
     observer.observe(document.body, {
-      attributes: true, // Watch heading id changes
-      attributeFilter: [`id`],
-      childList: true, // Watch for added/removed nodes
+      attributes: true,
+      childList: true,
       characterData: true, // Watch text changes inside existing headings
       subtree: true, // Watch all descendants, not just direct children
     })
@@ -466,10 +489,14 @@
     }
 
     const toc = aside.getBoundingClientRect()
-    intersecting = hide_on_intersect_elements().some((el) => {
-      const rect = el.getBoundingClientRect()
-      return !(toc.right < rect.left || toc.left > rect.right ||
-        toc.bottom < rect.top || toc.top > rect.bottom)
+    intersecting = hide_on_intersect_elements().some((element) => {
+      const rect = element.getBoundingClientRect()
+      return !(
+        toc.right < rect.left ||
+        toc.left > rect.right ||
+        toc.bottom < rect.top ||
+        toc.top > rect.bottom
+      )
     })
   }
 
@@ -482,26 +509,23 @@
   }
 
   // click and key handler for ToC items that scrolls to the heading
-  const li_click_key_handler =
-    (node: HTMLHeadingElement) => (event: LiEvent) => {
-      if (event instanceof KeyboardEvent) liProps.onkeydown?.(event)
-      else liProps.onclick?.(event)
-      if (event.defaultPrevented) return
-      if (event_targets_custom_interactive(event)) return
-      if (event instanceof MouseEvent && is_modified_click(event)) return
-      if (event instanceof KeyboardEvent && !is_activation_key(event.key)) {
-        return
-      }
-      const idx = headings.indexOf(node)
-      if (idx === -1) return
-      event.preventDefault()
-      set_open(false, `toc-item`)
-      activate_heading(node, idx)
+  const li_click_key_handler = (node: HTMLHeadingElement) => (event: LiEvent) => {
+    if (event instanceof KeyboardEvent) liProps.onkeydown?.(event)
+    else liProps.onclick?.(event)
+    if (event.defaultPrevented) return
+    if (event_targets_custom_interactive(event)) return
+    if (event instanceof MouseEvent && is_modified_click(event)) return
+    if (event instanceof KeyboardEvent && !is_activation_key(event.key)) {
+      return
     }
+    const idx = headings.indexOf(node)
+    if (idx === -1) return
+    event.preventDefault()
+    set_open(false, `toc-item`)
+    activate_heading(node, idx)
+  }
 
-  function scroll_to_active_toc_item(
-    behavior: `auto` | `smooth` | `instant` = `smooth`,
-  ) {
+  function scroll_to_active_toc_item(behavior: `auto` | `smooth` | `instant` = `smooth`) {
     if (keepActiveTocItemInView && activeTocLi && nav) {
       // scroll the active ToC item into the middle of the ToC container
       const top = activeTocLi.offsetTop - nav.offsetHeight / 2
@@ -532,10 +556,14 @@
       // ignore keyboard events when ToC is closed on mobile or inactive on desktop
       (!desktop && !is_open) ||
       (desktop && !toc_is_hovered && !toc_has_focus)
-    ) return
+    )
+      return
 
     if (event.key === `Tab`) {
       if (toc_has_focus) set_open(false, `tab`)
+      return
+    }
+    if (is_activation_key(event.key) && focus_is_in_custom_interactive_toc_item()) {
       return
     }
 
@@ -545,10 +573,13 @@
     if (event.key === `Escape` && is_open) set_open(false, `escape`)
     else if (current_toc_li) {
       const sibling_prop =
-        event.key === `ArrowDown` ? `nextElementSibling` :
-        event.key === `ArrowUp` ? `previousElementSibling` : null
+        event.key === `ArrowDown`
+          ? `nextElementSibling`
+          : event.key === `ArrowUp`
+            ? `previousElementSibling`
+            : null
       activeTocLi = sibling_prop
-        ? visible_toc_sibling(current_toc_li, sibling_prop) ?? current_toc_li
+        ? (visible_toc_sibling(current_toc_li, sibling_prop) ?? current_toc_li)
         : current_toc_li
       // move DOM focus onto the navigated item so the focused link's own keydown handler
       // can't override arrow-navigation on the next Enter/Space (tab->arrow->Enter)
@@ -635,23 +666,22 @@
       {#if titleSnippet}
         {@render titleSnippet()}
       {:else if title}
-        <h2
-          {...titleProps}
-          class={[`toc-title`, `toc-exclude`, titleProps.class]}
-        >
+        <h2 {...titleProps} class={[`toc-title`, `toc-exclude`, titleProps.class]}>
           {title}
         </h2>
       {/if}
-      <ol
-        {...olProps}
-      >
+      <ol {...olProps}>
         {#each headings as heading, idx (`${idx}-${heading.id}`)}
-          {@const indent = levels[idx] - minLevel}
+          {@const indent = levels[idx] - min_level}
           {@const collapsed = collapseSubheadings && !heading_visibility[idx]}
           {@const heading_id = heading_data[idx]?.id}
           {@const is_active = heading === activeHeading}
           {@const item_tabindex = collapsed ? -1 : 0}
-          <!-- svelte-ignore a11y_no_noninteractive_tabindex - custom tocItem snippets may not provide their own focusable element -->
+          {@const use_fallback_toc_item =
+            tocItem && toc_item_has_interactive[idx] === false}
+          {@const item_margin_left = `calc(${indent} * var(--toc-indent-per-level, 1em))`}
+          {@const item_font_size = `max(var(--toc-li-font-size-min, 2ex), calc(var(--toc-li-font-size-base, 3ex) - ${indent} * var(--toc-li-font-size-step, 0.1ex)))`}
+          <!-- svelte-ignore a11y_no_noninteractive_tabindex - fallback for custom tocItem snippets without their own focusable element -->
           <li
             {...liProps}
             class:active={is_active}
@@ -659,10 +689,10 @@
             aria-hidden={collapsed || undefined}
             aria-current={tocItem && is_active ? `location` : undefined}
             bind:this={tocItems[idx]}
-            role={tocItem ? `link` : undefined}
-            tabindex={tocItem ? item_tabindex : undefined}
-            style:margin-left="calc({indent} * var(--toc-indent-per-level, 1em))"
-            style:font-size="max(var(--toc-li-font-size-min, 2ex), calc(var(--toc-li-font-size-base, 3ex) - {indent} * var(--toc-li-font-size-step, 0.1ex)))"
+            role={use_fallback_toc_item ? `link` : undefined}
+            tabindex={use_fallback_toc_item ? item_tabindex : undefined}
+            style:margin-left={item_margin_left}
+            style:font-size={item_font_size}
             onclick={li_click_key_handler(heading)}
             onkeydown={li_click_key_handler(heading)}
           >
@@ -731,7 +761,10 @@
     display: block;
     text-decoration: none;
   }
-  aside.toc > nav > ol > li > a:focus-visible {
+  :is(
+    aside.toc > nav > ol > li:focus-visible,
+    aside.toc > nav > ol > li > a:focus-visible
+  ) {
     outline: var(--toc-focus-outline, 2px solid currentColor);
     outline-offset: var(--toc-focus-outline-offset, 1px);
   }

--- a/src/lib/Toc.svelte
+++ b/src/lib/Toc.svelte
@@ -332,6 +332,7 @@
       if (record.type !== `attributes` || !(record.target instanceof Element))
         return false
       const target = record.target
+      if (target === document.body) return false
       return (
         selector_is_valid(`headingSelector`, headingSelector) &&
         (target.closest(headingSelector) !== null ||

--- a/src/routes/(demos)/collapse-headings/+page.svelte
+++ b/src/routes/(demos)/collapse-headings/+page.svelte
@@ -12,17 +12,15 @@
   ]
 
   const lorem = `Lorem ipsum dolor sit amet. `.repeat(8)
-  const filler = `This is sample content to demonstrate scrolling behavior. `.repeat(
-    4,
-  )
+  const filler = `This is sample content to demonstrate scrolling behavior. `.repeat(4)
 </script>
 
 <main>
   <h1>Collapse Subheadings Demo</h1>
   <p>
-    This demo shows the <code>collapseSubheadings</code> feature. Select different modes
-    to see how the TOC collapses and expands based on the active heading. Scroll through
-    the page to watch child headings appear and disappear in the TOC as you navigate.
+    This demo shows the <code>collapseSubheadings</code> feature. Select different modes to
+    see how the TOC collapses and expands based on the active heading. Scroll through the page
+    to watch child headings appear and disappear in the TOC as you navigate.
   </p>
 
   <div class="controls">

--- a/src/routes/(demos)/hide-on-intersect/+page.svelte
+++ b/src/routes/(demos)/hide-on-intersect/+page.svelte
@@ -1,8 +1,8 @@
 <h2>The hideOnIntersect Feature</h2>
 <p>
-  This page demonstrates how the <code>hideOnIntersect</code> prop automatically hides the
-  table of contents when it would overlap with full-width elements like hero sections,
-  banners, or images. Scroll down to see the TOC disappear and reappear.
+  This page demonstrates how the <code>hideOnIntersect</code> prop automatically hides the table
+  of contents when it would overlap with full-width elements like hero sections, banners, or
+  images. Scroll down to see the TOC disappear and reappear.
 </p>
 <p>
   Watch the TOC on the right side of the screen. As you scroll through this page, it will
@@ -12,8 +12,8 @@
 <h2>Why This Matters</h2>
 <p>
   Fixed or sticky sidebars can clash visually with full-width content that's designed to
-  span the entire viewport. The <code>hideOnIntersect</code> prop solves this by
-  temporarily hiding the TOC when such elements scroll into its space.
+  span the entire viewport. The <code>hideOnIntersect</code> prop solves this by temporarily
+  hiding the TOC when such elements scroll into its space.
 </p>
 <p>
   This is useful for documentation with hero sections, image galleries, or any layout that
@@ -29,10 +29,12 @@
 
 <h3>Usage Example</h3>
 <pre>
-<code>&lt;Toc hideOnIntersect=".full-width-banner" /&gt;
+<code
+    >&lt;Toc hideOnIntersect=".full-width-banner" /&gt;
 
 &lt;!-- Or with multiple selectors --&gt;
-&lt;Toc hideOnIntersect=".hero, .full-width-image" /&gt;</code></pre>
+&lt;Toc hideOnIntersect=".hero, .full-width-image" /&gt;</code
+  ></pre>
 
 <h2>Desktop Only</h2>
 <p>
@@ -41,8 +43,8 @@
   is unnecessary.
 </p>
 <p>
-  The breakpoint for desktop/mobile is controlled by the <code>breakpoint</code> prop,
-  which defaults to 1000px.
+  The breakpoint for desktop/mobile is controlled by the <code>breakpoint</code> prop, which
+  defaults to 1000px.
 </p>
 
 <div class="hero-banner" data-testid="banner-1">
@@ -66,12 +68,13 @@
 <p>
   When hidden by intersection, the TOC sets <code>aria-hidden="true"</code> so screen
   readers skip the temporarily hidden content. Visibility is controlled via CSS (<code
-  >opacity: 0</code>, <code>pointer-events: none</code>) to enable smooth fade transitions
-  while keeping the element in the layout flow.
+    >opacity: 0</code
+  >, <code>pointer-events: none</code>) to enable smooth fade transitions while keeping
+  the element in the layout flow.
 </p>
 <p>
-  This approach is preferred over using the <code>hidden</code> attribute or removing the
-  element from the DOM, as it maintains layout stability and allows for smooth animations.
+  This approach is preferred over using the <code>hidden</code> attribute or removing the element
+  from the DOM, as it maintains layout stability and allows for smooth animations.
 </p>
 
 <h2>Edge Cases Handled</h2>
@@ -115,9 +118,9 @@
 
 <h2>Summary</h2>
 <p>
-  The <code>hideOnIntersect</code> prop provides a clean solution for pages that need both
-  a sticky table of contents and full-width visual elements. It's performant, accessible,
-  and handles edge cases gracefully.
+  The <code>hideOnIntersect</code> prop provides a clean solution for pages that need both a
+  sticky table of contents and full-width visual elements. It's performant, accessible, and
+  handles edge cases gracefully.
 </p>
 
 <style>
@@ -149,7 +152,8 @@
     text-align: center;
     color: white;
   }
-  .hero-banner::before, .info-banner::before {
+  .hero-banner::before,
+  .info-banner::before {
     content: '';
     position: absolute;
     inset: 0;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,9 +19,7 @@
     .filter((route) => route !== `/`) // home handled separately
 
   // Show home link in nav when not on home page
-  let nav_routes = $derived(
-    page.url.pathname === `/` ? all_routes : [`/`, ...all_routes],
-  )
+  let nav_routes = $derived(page.url.pathname === `/` ? all_routes : [`/`, ...all_routes])
 
   const actions = all_routes.map((route) => ({
     label: route,
@@ -43,7 +41,11 @@
 
 {#if !routes_without_toc.includes(page.url.pathname)}
   <Toc
-    headingSelector={page.url.pathname === `/changelog` ? `main > h2` : `main :where(h2, h3)`}
-    hideOnIntersect={page.url.pathname === `/hide-on-intersect` ? `.hero-banner, .info-banner` : null}
+    headingSelector={page.url.pathname === `/changelog`
+      ? `main > h2`
+      : `main :where(h2, h3)`}
+    hideOnIntersect={page.url.pathname === `/hide-on-intersect`
+      ? `.hero-banner, .info-banner`
+      : null}
   />
 {/if}

--- a/tests/playwright/toc.test.ts
+++ b/tests/playwright/toc.test.ts
@@ -9,14 +9,14 @@ test.describe(`collapseSubheadings`, () => {
   async function scroll_to_element(page: Page, selector: string): Promise<void> {
     const heading_text = await page.evaluate((selector_to_scroll) => {
       const element = document.querySelector(selector_to_scroll)
-      if (element) {
-        element.scrollIntoView({ behavior: `instant`, block: `start` })
-        return element.textContent?.trim() ?? null
+      if (!element) {
+        throw new Error(`scroll_to_element target not found: ${selector_to_scroll}`)
       }
-      return null
+      element.scrollIntoView({ behavior: `instant`, block: `start` })
+      return element.textContent?.trim() ?? ``
     }, selector)
     // Wait for active heading to update in TOC
-    if (heading_text !== null && heading_text !== ``) {
+    if (heading_text !== ``) {
       await expect(page.locator(`aside.toc > nav > ol > li.active`)).toContainText(
         heading_text,
         { timeout: 1000 },

--- a/tests/playwright/toc.test.ts
+++ b/tests/playwright/toc.test.ts
@@ -1,14 +1,17 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+const trimmed_texts = async (locator: Locator): Promise<string[]> =>
+  (await locator.allTextContents()).map((text) => text.trim())
 
 test.describe(`collapseSubheadings`, () => {
   test.describe.configure({ mode: `parallel` })
   // Helper to scroll to element and wait for TOC to update
-  async function scroll_to_element(page: Page, selector: string) {
-    const heading_text = await page.evaluate((sel) => {
-      const element = document.querySelector(sel)
+  async function scroll_to_element(page: Page, selector: string): Promise<void> {
+    const heading_text = await page.evaluate((selector_to_scroll) => {
+      const element = document.querySelector(selector_to_scroll)
       if (element) {
         element.scrollIntoView({ behavior: `instant`, block: `start` })
-        return element.textContent.trim()
+        return element.textContent?.trim() ?? null
       }
       return null
     }, selector)
@@ -36,101 +39,28 @@ test.describe(`collapseSubheadings`, () => {
     await expect(collapsed_items).toHaveCount(0)
   })
 
-  test(`top-level headings always visible with full nested collapse`, async ({
-    page,
-  }) => {
-    // Enable full nested collapse
+  test(`full nested collapse follows active heading hierarchy`, async ({ page }) => {
     await page.click(`input[value="true"]`)
+    await scroll_to_element(page, `#getting-started`)
 
     const toc_items = page.locator(`aside.toc > nav > ol > li`)
-    await expect(toc_items).toHaveCount(41)
-
-    // h2 sections should never be collapsed
     const getting_started = toc_items.filter({ hasText: /^Getting Started$/ })
-    const configuration = toc_items.filter({ hasText: /^Configuration$/ })
-    const advanced = toc_items.filter({ hasText: /^Advanced Features$/ })
+    const installation = toc_items.filter({ hasText: /^Installation$/ })
+    const npm_setup = toc_items.filter({ hasText: /^NPM Setup$/ })
+    const styling = toc_items.filter({ hasText: /^Styling Options$/ })
 
     await expect(getting_started).not.toHaveClass(/collapsed/)
-    await expect(configuration).not.toHaveClass(/collapsed/)
-    await expect(advanced).not.toHaveClass(/collapsed/)
-  })
-
-  test(`nested collapse hides h4s when h3 parent not active`, async ({ page }) => {
-    // Enable full nested collapse
-    await page.click(`input[value="true"]`)
-
-    // Scroll to Getting Started to make it active
-    await scroll_to_element(page, `#getting-started`)
-
-    const toc_items = page.locator(`aside.toc > nav > ol > li`)
-
-    // With Getting Started (h2) active, h3s under it should be visible
-    const installation = toc_items.filter({ hasText: /^Installation$/ })
     await expect(installation).not.toHaveClass(/collapsed/)
-
-    // But h4s should be collapsed (their h3 parent is not active)
-    const npm_setup = toc_items.filter({ hasText: /^NPM Setup$/ })
-    const pnpm_setup = toc_items.filter({ hasText: /^PNPM Setup$/ })
     await expect(npm_setup).toHaveClass(/collapsed/)
-    await expect(pnpm_setup).toHaveClass(/collapsed/)
-
-    // h3s under inactive h2 Configuration should be collapsed
-    const styling = toc_items.filter({ hasText: /^Styling Options$/ })
     await expect(styling).toHaveClass(/collapsed/)
-  })
 
-  test(`h4s expand when scrolling to their h3 parent`, async ({ page }) => {
-    // Enable full nested collapse
-    await page.click(`input[value="true"]`)
-
-    const toc_items = page.locator(`aside.toc > nav > ol > li`)
-    const npm_setup = toc_items.filter({ hasText: /^NPM Setup$/ })
-
-    // First scroll to Getting Started to set context - h4s should be collapsed
-    await scroll_to_element(page, `#getting-started`)
-    await expect(npm_setup).toHaveClass(/collapsed/)
-
-    // Now scroll to Installation (h3) - h4s under it should expand
     await scroll_to_element(page, `#installation`)
 
-    // h4s under Installation should now be visible
-    await expect(npm_setup).not.toHaveClass(/collapsed/)
     const pnpm_setup = toc_items.filter({ hasText: /^PNPM Setup$/ })
-    await expect(pnpm_setup).not.toHaveClass(/collapsed/)
-
-    // h4 under Basic Usage should still be collapsed (different h3 parent)
     const import_component = toc_items.filter({ hasText: /^Importing the Component$/ })
+    await expect(npm_setup).not.toHaveClass(/collapsed/)
+    await expect(pnpm_setup).not.toHaveClass(/collapsed/)
     await expect(import_component).toHaveClass(/collapsed/)
-  })
-
-  test(`threshold mode h3 expands all h4s when h3 ancestor visible`, async ({ page }) => {
-    // Enable h3 threshold mode
-    await page.click(`input[value="h3"]`)
-
-    // Scroll to Getting Started to make it active
-    await scroll_to_element(page, `#getting-started`)
-
-    const toc_items = page.locator(`aside.toc > nav > ol > li`)
-
-    // With h3 threshold, when h2 Getting Started is active:
-    // - All h3s under Getting Started are visible
-    // - ALL h4s+ under those h3s should also be visible (no independent collapse)
-    const installation = toc_items.filter({ hasText: /^Installation$/ })
-    const basic_usage = toc_items.filter({ hasText: /^Basic Usage$/ })
-    await expect(installation).not.toHaveClass(/collapsed/)
-    await expect(basic_usage).not.toHaveClass(/collapsed/)
-
-    // h4s should be visible with threshold mode
-    const npm_setup = toc_items.filter({ hasText: /^NPM Setup$/ })
-    const pnpm_setup = toc_items.filter({ hasText: /^PNPM Setup$/ })
-    const import_component = toc_items.filter({ hasText: /^Importing the Component$/ })
-    await expect(npm_setup).not.toHaveClass(/collapsed/)
-    await expect(pnpm_setup).not.toHaveClass(/collapsed/)
-    await expect(import_component).not.toHaveClass(/collapsed/)
-
-    // h3s under inactive Configuration should still be collapsed
-    const styling = toc_items.filter({ hasText: /^Styling Options$/ })
-    await expect(styling).toHaveClass(/collapsed/)
   })
 
   test(`collapsed items have correct accessibility attributes`, async ({ page }) => {
@@ -235,24 +165,6 @@ test.describe(`collapseSubheadings`, () => {
     await expect(npm_setup).not.toHaveClass(/collapsed/)
   })
 
-  test(`maintains correct active heading highlight while collapsed`, async ({ page }) => {
-    // Enable full nested collapse
-    await page.click(`input[value="true"]`)
-
-    // Test that scrolling to different h2 sections updates active state
-    await scroll_to_element(page, `#getting-started`)
-    let active_item = page.locator(`aside.toc > nav > ol > li.active`)
-    await expect(active_item).toContainText(`Getting Started`)
-
-    await scroll_to_element(page, `#configuration`)
-    active_item = page.locator(`aside.toc > nav > ol > li.active`)
-    await expect(active_item).toContainText(`Configuration`)
-
-    await scroll_to_element(page, `#advanced-features`)
-    active_item = page.locator(`aside.toc > nav > ol > li.active`)
-    await expect(active_item).toContainText(`Advanced Features`)
-  })
-
   test(`collapsed items have correct CSS properties`, async ({ page }) => {
     // Enable full nested collapse
     await page.click(`input[value="true"]`)
@@ -268,7 +180,9 @@ test.describe(`collapseSubheadings`, () => {
 
     // Verify opacity reaches 0 after CSS transition completes
     await expect(async () => {
-      const opacity = await collapsed_item.evaluate((el) => getComputedStyle(el).opacity)
+      const opacity = await collapsed_item.evaluate(
+        (element) => getComputedStyle(element).opacity,
+      )
       expect(opacity).toBe(`0`)
     }).toPass({ timeout: 500 })
   })
@@ -339,9 +253,7 @@ test.describe(`hideOnIntersect`, () => {
     const toc_items = page.locator(`aside.toc > nav > ol > li`)
     await toc_items.first().waitFor()
 
-    const toc_headings = await toc_items
-      .allTextContents()
-      .then((texts) => texts.map((text) => text.trim()))
+    const toc_headings = await trimmed_texts(toc_items)
 
     expect(toc_headings).toEqual(expected_headings)
   })
@@ -356,28 +268,24 @@ test.describe(`Toc`, () => {
     // Test each page separately to avoid await in loop
     await page.goto(`/`, { waitUntil: `networkidle` })
 
-    let expected_headings = await page.locator(`main :where(h2, h3)`).allTextContents()
+    let expected_headings = await trimmed_texts(page.locator(`main :where(h2, h3)`))
 
     // wait for ToC to render headings
     await page.waitForSelector(`aside.toc > nav > ol > li`)
 
-    let toc_headings = (
-      await page.locator(`aside.toc > nav > ol > li`).allTextContents()
-    ).map((h) => h.trim())
+    let toc_headings = await trimmed_texts(page.locator(`aside.toc > nav > ol > li`))
 
     expect(toc_headings).toEqual(expected_headings)
 
     // Test long-page
     await page.goto(`/long-page`, { waitUntil: `networkidle` })
 
-    expected_headings = await page.locator(`main :where(h2, h3)`).allTextContents()
+    expected_headings = await trimmed_texts(page.locator(`main :where(h2, h3)`))
 
     // wait for ToC to render headings
     await page.waitForSelector(`aside.toc > nav > ol > li`)
 
-    toc_headings = (
-      await page.locator(`aside.toc > nav > ol > li`).allTextContents()
-    ).map((h) => h.trim())
+    toc_headings = await trimmed_texts(page.locator(`aside.toc > nav > ol > li`))
 
     expect(toc_headings).toEqual(expected_headings)
   })
@@ -422,13 +330,13 @@ test.describe(`Toc`, () => {
       document.querySelector(`main`)?.append(new_heading)
     })
 
-    const page_headings_after_add = await page
-      .locator(`main :where(h2, h3)`)
-      .allTextContents()
+    const page_headings_after_add = await trimmed_texts(
+      page.locator(`main :where(h2, h3)`),
+    )
 
-    const toc_headings_after_add = (
-      await page.locator(`aside.toc > nav > ol > li`).allTextContents()
-    ).map((li_text) => li_text.trim())
+    const toc_headings_after_add = await trimmed_texts(
+      page.locator(`aside.toc > nav > ol > li`),
+    )
 
     expect(toc_headings_after_add).toEqual(page_headings_after_add)
 
@@ -437,15 +345,15 @@ test.describe(`Toc`, () => {
       document.querySelector(`h2`)?.remove()
     })
 
-    const page_headings_after_remove = await page
-      .locator(`main :where(h2, h3)`)
-      .allTextContents()
-
-    const toc_headings_after_remove = (
-      await page.locator(`aside.toc > nav > ol > li`).allTextContents()
-    ).map((li_text) => li_text.trim())
-
-    expect(toc_headings_after_remove).toEqual(page_headings_after_remove)
+    await expect(async () => {
+      const page_headings_after_remove = await trimmed_texts(
+        page.locator(`main :where(h2, h3)`),
+      )
+      const toc_headings_after_remove = await trimmed_texts(
+        page.locator(`aside.toc > nav > ol > li`),
+      )
+      expect(toc_headings_after_remove).toEqual(page_headings_after_remove)
+    }).toPass({ timeout: 1000 })
   })
 
   // Tests for issue #50: clicking ToC items should immediately highlight the correct heading

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -317,6 +317,7 @@ describe(`Toc`, () => {
 
     const item = doc_query(`aside.toc li`)
     expect(item.getAttribute(`tabindex`)).toBe(`0`)
+    expect(item.getAttribute(`role`)).toBe(`link`)
     expect(item.getAttribute(`aria-current`)).toBe(`location`)
     expect(item.querySelector(`a`)).toBeNull()
     expect(item.querySelector(`.custom-toc-item`)?.textContent).toBe(`intro:Intro`)
@@ -338,6 +339,7 @@ describe(`Toc`, () => {
       n_anchors: 0,
       selector: `aside.toc li > button.custom-button`,
       scrolls: false,
+      checks_keyboard: true,
     },
     {
       desc: `non-interactive span scrolls to the heading`,
@@ -347,34 +349,63 @@ describe(`Toc`, () => {
       selector: `aside.toc li > span.plain`,
       scrolls: true,
     },
-  ])(`tocItem $desc`, async ({ html, n_anchors, selector, scrolls }) => {
-    set_body(`<h2 id="intro">Intro</h2>`)
-    const replace_state_mock = vi.spyOn(history, `replaceState`)
-    const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
-    Element.prototype.scrollIntoView = scroll_into_view_mock
+  ])(
+    `tocItem $desc`,
+    async ({ html, n_anchors, selector, scrolls, checks_keyboard = false }) => {
+      set_body(`<h2 id="first">First</h2><h2 id="second">Second</h2>`)
+      mock_active_heading(`first`)
+      const replace_state_mock = vi.spyOn(history, `replaceState`)
+      const scroll_into_view_mock = vi.fn<Element[`scrollIntoView`]>()
+      Element.prototype.scrollIntoView = scroll_into_view_mock
 
-    mount(Toc, {
-      target: document.body,
-      props: {
-        tocItem: createRawSnippet<[HTMLHeadingElement]>((heading) => ({
-          render: () => html(heading()),
-        })),
-      },
-    })
-    await tick()
+      mount(Toc, {
+        target: document.body,
+        props: {
+          tocItem: createRawSnippet<[HTMLHeadingElement]>((heading) => ({
+            render: () => html(heading()),
+          })),
+        },
+      })
+      await tick()
 
-    const item = doc_query(`aside.toc li`)
-    expect(item.querySelectorAll(`a`)).toHaveLength(n_anchors)
+      const item = doc_query(`aside.toc li`)
+      expect(item.querySelectorAll(`a`)).toHaveLength(n_anchors)
+      expect(item.getAttribute(`role`)).toBe(scrolls ? `link` : null)
+      expect(item.getAttribute(`tabindex`)).toBe(scrolls ? `0` : null)
 
-    const event = new MouseEvent(`click`, { bubbles: true, cancelable: true })
-    doc_query(selector).dispatchEvent(event)
+      const event = new MouseEvent(`click`, { bubbles: true, cancelable: true })
+      doc_query(selector).dispatchEvent(event)
 
-    // a nested interactive element keeps native behavior (no preventDefault, no scroll);
-    // plain content falls through to the li handler which scrolls and updates the fragment
-    expect(event.defaultPrevented).toBe(scrolls)
-    expect(scroll_into_view_mock).toHaveBeenCalledTimes(scrolls ? 1 : 0)
-    expect(replace_state_mock.mock.calls).toEqual(scrolls ? [[{}, ``, `#intro`]] : [])
-  })
+      // a nested interactive element keeps native behavior (no preventDefault, no scroll);
+      // plain content falls through to the li handler which scrolls and updates the fragment
+      expect(event.defaultPrevented).toBe(scrolls)
+      expect(scroll_into_view_mock).toHaveBeenCalledTimes(scrolls ? 1 : 0)
+      expect(replace_state_mock.mock.calls).toEqual(scrolls ? [[{}, ``, `#first`]] : [])
+
+      if (checks_keyboard) {
+        const buttons =
+          document.querySelectorAll<HTMLButtonElement>(`aside.toc li > button`)
+        buttons[0].focus()
+        buttons[0].dispatchEvent(
+          new KeyboardEvent(`keydown`, { key: `ArrowDown`, bubbles: true }),
+        )
+        await tick()
+
+        expect(document.activeElement).toBe(buttons[1])
+
+        const enter_event = new KeyboardEvent(`keydown`, {
+          key: `Enter`,
+          bubbles: true,
+          cancelable: true,
+        })
+        buttons[1].dispatchEvent(enter_event)
+
+        expect(enter_event.defaultPrevented).toBe(false)
+        expect(scroll_into_view_mock).not.toHaveBeenCalled()
+        expect(replace_state_mock).not.toHaveBeenCalled()
+      }
+    },
+  )
 
   test(`modified clicks on ToC links keep native browser behavior`, async () => {
     set_body(`<h2 id="intro">Intro</h2>`)
@@ -1032,6 +1063,22 @@ describe(`Toc`, () => {
     expect(doc_query(`aside.toc li > a`).getAttribute(`href`)).toBe(`#new`)
   })
 
+  test(`selector-driven attribute changes update heading membership`, async () => {
+    set_body(`<h2 class="toc-exclude">Alpha</h2><h2>Beta</h2><h5 id="gamma">Gamma</h5>`)
+    mount(Toc, {
+      target: document.body,
+      props: { headingSelector: `:is(h2, h5[data-toc-heading])` },
+    })
+    await tick()
+    expect(doc_query(`aside.toc ol`).textContent).toBe(`Beta`)
+
+    doc_query(`.toc-exclude`).classList.remove(`toc-exclude`)
+    doc_query(`#gamma`).setAttribute(`data-toc-heading`, ``)
+    await tick()
+
+    expect(doc_query(`aside.toc ol`).textContent).toBe(`AlphaBetaGamma`)
+  })
+
   test(`rebinds when a heading element is replaced with identical content`, async () => {
     set_body(`<h2 id="a">Title</h2>`)
     mount(Toc, { target: document.body })
@@ -1537,8 +1584,11 @@ describe(`Element Prop Bags`, () => {
     },
   )
 
-  test(`liProps.style preserves generated margin-left and font-size styles`, async () => {
-    ensure_content_for_toc_elements([`<h2>Single Heading</h2>`])
+  test(`liProps.style preserves generated styles without multiline whitespace`, async () => {
+    ensure_content_for_toc_elements([
+      `<h2>Parent Heading</h2>`,
+      `<h3>Nested Heading</h3>`,
+    ])
 
     mount(Toc, {
       target: document.body,
@@ -1546,10 +1596,17 @@ describe(`Element Prop Bags`, () => {
     })
     await tick()
 
-    const style_attribute = doc_query(`aside.toc nav ol li`).getAttribute(`style`)
+    const style_attribute = doc_query(`aside.toc nav ol li:nth-child(2)`).getAttribute(
+      `style`,
+    )
     expect(style_attribute).toContain(`padding-left: 10px;`)
-    expect(style_attribute).toContain(`margin-left`)
-    expect(style_attribute).toContain(`font-size`)
+    expect(style_attribute).toContain(
+      `margin-left: calc(1 * var(--toc-indent-per-level, 1em))`,
+    )
+    expect(style_attribute).toContain(
+      `font-size: max(var(--toc-li-font-size-min, 2ex), calc(var(--toc-li-font-size-base, 3ex) - 1 * var(--toc-li-font-size-step, 0.1ex)))`,
+    )
+    expect(style_attribute).not.toContain(`\n`)
   })
 
   test.each([

--- a/tests/vitest/toc.svelte.test.ts
+++ b/tests/vitest/toc.svelte.test.ts
@@ -1038,16 +1038,24 @@ describe(`Toc`, () => {
 
   test(`unrelated text-node data edits do not rebuild active heading`, async () => {
     set_body(`<h2 id="a">Alpha</h2><h2 id="b">Beta</h2><p>Original</p>`)
-    mount(Toc, { target: document.body })
+    const get_heading_data = vi.fn((node: HTMLHeadingElement) => ({
+      id: node.id,
+      level: Number(node.nodeName[1]),
+      title: node.textContent ?? ``,
+    }))
+    mount(Toc, { target: document.body, props: { getHeadingData: get_heading_data } })
     await tick()
+    get_heading_data.mockClear()
 
     expect(doc_query(`aside.toc li.active`).textContent.trim()).toBe(`Beta`)
     mock_active_heading(`a`)
 
     ;(doc_query(`p`).firstChild as Text).data = `Changed`
+    document.body.setAttribute(`data-theme`, `dark`)
     await tick()
 
     expect(doc_query(`aside.toc li.active`).textContent.trim()).toBe(`Beta`)
+    expect(get_heading_data).not.toHaveBeenCalled()
   })
 
   test(`heading id attribute changes update link targets`, async () => {


### PR DESCRIPTION
## Summary
- Preserve keyboard behavior for custom interactive `tocItem` content while keeping fallback ToC item navigation.
- Tighten ToC mutation handling and document focus-visible selectors.
- Prune redundant Playwright coverage while keeping browser-only regressions and focused Vitest coverage.

## Validation
- `pnpm exec vitest run tests/vitest/toc.svelte.test.ts`
- `pnpm exec playwright test tests/playwright/toc.test.ts`
- pre-commit hooks ran `vp check --fix` and Svelte checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TOC entries now better handle custom content, including improved keyboard navigation and focus targeting for interactive elements inside TOC items.
* **Bug Fixes**
  * Enhanced TOC activation/focus behavior and more accurate link-like behavior when custom TOC content isn’t directly focusable.
  * TOC heading membership and active highlighting update more reliably as page structure/content changes.
* **Documentation**
  * Updated styling guidance to cover the expanded focus-visible behavior for TOC list items and links.
* **Chores**
  * Updated the project’s package manager version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->